### PR TITLE
Inline argparse and improve linking on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ endif()
 # cmake < 3.4.0 has problems with projects that use C++ but not C,
 # especially in the FindThreads module (when header files are checked).
 if(CMAKE_VERSION VERSION_LESS "3.4.0")
+	if(WIN32)
+		# Need cmake >= 3.4.0 to enable WINDOWS_EXPORT_ALL_SYMBOLS for nyan
+		message(FATAL_ERROR "Cannot build with cmake ${CMAKE_VERSION} < 3.4.0 for MSVC.")
+	endif()
 	message(WARNING "using cmake ${CMAKE_VERSION} < 3.4.0, falling back and setting CC=CXX.")
 	project(nyan VERSION ${nyan_VERSION} LANGUAGES C CXX)
 

--- a/nyan/CMakeLists.txt
+++ b/nyan/CMakeLists.txt
@@ -76,6 +76,9 @@ if(UNIX)
 
 	set_target_properties(nyan PROPERTIES LINK_FLAGS "-Wl,--no-undefined")
 endif()
+if(WIN32)
+	set_target_properties(nyan PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 set_target_properties(nyan PROPERTIES
 	VERSION ${nyan_VERSION}

--- a/nyan/nyan_tool.cpp
+++ b/nyan/nyan_tool.cpp
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
-#include <getopt.h>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -165,54 +164,34 @@ std::pair<flags_t, params_t> argparse(int argc, char** argv) {
 		{option_param::FILE, ""}
 	};
 
-	int option_index = 0;
-
-	while (true) {
-		static struct option long_options[] = {
-			{"help", no_argument, 0, 'h'},
-			{"file", required_argument, 0, 'f'},
-			{"break", no_argument, 0, 'b'},
-			{"echo", no_argument, 0, 0},
-			{"test-parser", no_argument, 0, 0},
-			{0, 0, 0, 0}
-		};
-
-		int c = getopt_long(argc, argv,
-		                    "hf:b",
-		                    long_options, &option_index);
-		if (c == -1)
-			break;
-
-		switch (c) {
-		case 0: {
-			const char *op_name = long_options[option_index].name;
-			if (strcmp("test-parser", op_name) == 0) {
-				flags[option_flag::TEST_PARSER] = true;
+	for (int option_index = 1; option_index < argc; ++option_index) {
+		std::string arg = argv[option_index];
+		if (arg == "-h" or arg == "--help") {
+			help();
+			exit(0);
+		}
+		else if (arg == "-f" or arg == "--file") {
+			++option_index;
+			if (option_index == argc) {
+				std::cerr << "Filename not specified" << std::endl;
+				help();
+				exit(-1);
 			}
-
-			break;
+			params[option_param::FILE] = argv[option_index];
 		}
-		case 'f':
-			params[option_param::FILE] = optarg;
-			break;
-
-		case 'h': help(); exit(0); break;
-		case 'b': Error::enable_break(true); break;
-		case '?': break;
-
-		default: printf("error in getopt config: "
-		                "returned character code 0%o\n", c);
+		else if (arg == "-b" or arg == "--break") {
+			Error::enable_break(true);
 		}
-	}
-
-	// required positional args
-	if (option_index < argc) {
-		while (optind < argc) {
-			std::cout << argv[option_index] << std::endl;
-			option_index += 1;
+		else if (arg == "--echo") {
+			flags[option_flag::ECHO] = true;
+		}
+		else if (arg == "--test-parser") {
+			flags[option_flag::TEST_PARSER] = true;
+		}
+		else {
+			std::cerr << "Unused argument: " << arg << std::endl;
 		}
 	}
-
 
 	return std::make_pair(flags, params);
 }


### PR DESCRIPTION
Remove `getopt.h` as it is not available for MSVC.
 - inline the argument parsing logic in `nyan::argparse`.

Export nyan library symbols using [`WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html#windows-export-all-symbols).
 - require `CMAKE_VERSION` at least 3.4 on Windows for the same.