### PR TITLE
Lexer: remove flex generated header

### DIFF
--- a/nyan/CMakeLists.txt
+++ b/nyan/CMakeLists.txt
@@ -4,12 +4,11 @@
 
 find_package(FLEX REQUIRED)
 
-set(nyanl_cpp "${CMAKE_CURRENT_SOURCE_DIR}/lexer/flex.gen.cpp")
-set(nyanl_h "${CMAKE_CURRENT_SOURCE_DIR}/lexer/flex.gen.h")
+set(nyanl_cpp "${CMAKE_CURRENT_BINARY_DIR}/flex.gen.cpp")
 set(nyanl_lpp "${CMAKE_CURRENT_SOURCE_DIR}/lexer/flex.lpp")
 
-add_custom_command(OUTPUT ${nyanl_cpp} ${nyanl_h}
-	COMMAND ${FLEX_EXECUTABLE} -Ca --header-file=${nyanl_h} -o ${nyanl_cpp} ${nyanl_lpp}
+add_custom_command(OUTPUT ${nyanl_cpp}
+	COMMAND ${FLEX_EXECUTABLE} -Ca -o ${nyanl_cpp} ${nyanl_lpp}
 	VERBATIM
 	DEPENDS ${nyanl_lpp}
 	COMMENT "[flex] Generating scanner with flex ${FLEX_VERSION}"
@@ -109,6 +108,7 @@ target_include_directories(nyan
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
 	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/lexer
 		${FLEX_INCLUDE_DIRS}
 )
 

--- a/nyan/lexer/.gitignore
+++ b/nyan/lexer/.gitignore
@@ -1,2 +1,0 @@
-# generated files
-flex.gen.*

--- a/nyan/lexer/flex.lpp
+++ b/nyan/lexer/flex.lpp
@@ -25,6 +25,7 @@ using namespace std::string_literals;
 %option warn nodefault
 %option yylineno
 %option nounistd
+%option noyywrap
 %option never-interactive
 
 
@@ -77,11 +78,3 @@ float          -?({digit}+\.{digit}*|{digit}*\.{digit}+)
 .                       { throw impl->error("invalid char: "s + yytext); }
 
 %%
-
-
-// No file wrapper needed for now.
-// And of course the noyywrap option is broken and generates
-// this snippet in both the header and cpp file.
-int yyFlexLexer::yywrap() {
-	return 1;
-}

--- a/nyan/lexer/impl.h
+++ b/nyan/lexer/impl.h
@@ -2,8 +2,7 @@
 #pragma once
 
 #ifndef yyFlexLexer
-#define YY_NO_UNISTD_H
-#include "flex.gen.h"
+#include <FlexLexer.h>
 #endif
 
 #include <queue>


### PR DESCRIPTION
Modifications:
- use `FlexLexer.h` instead of `flex.gen.h`
- move `flex.gen.cpp` to binary directory
- builds completely out-of-source
- use `option noyywrap`