### PR TITLE
buildsystem: use homebrew flex on macOS

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -14,6 +14,7 @@ _the nyan authors_ are:
 | Michael Enßlin              | mic_e                       | michael@ensslin.cc                    |
 | Andre Kupka                 | freakout                    | kupka@in.tum.de                       |
 | Tushar Maheshwari           | tusharpm                    | tushar27192@gmail.com                 |
+| Andrew Thompson             | mrwerdo                     | mrwerdo331@me.com                     |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/nyan/CMakeLists.txt
+++ b/nyan/CMakeLists.txt
@@ -1,6 +1,15 @@
 # source file configuration
 # for the resulting nyan library
 
+if (APPLE)
+    execute_process(COMMAND brew --prefix flex
+                    OUTPUT_VARIABLE BREW_FLEX_HOME
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (EXISTS "${BREW_FLEX_HOME}/bin/flex")
+        message(STATUS "Found homebrew flex, using it instead.")
+        set(FLEX_EXECUTABLE "${BREW_FLEX_HOME}/bin/flex")
+    endif ()
+endif ()
 
 find_package(FLEX 2.6 REQUIRED)
 


### PR DESCRIPTION
This enables nyan to find (and prefer) the install homebrew version on macOS.