### PR TITLE
Clang 5: Fix C++11 Narrowing

### DIFF
--- a/nyan/lexer/impl.cpp
+++ b/nyan/lexer/impl.cpp
@@ -52,8 +52,8 @@ TokenizeError Impl::error(const std::string &msg) {
 		Location{
 			this->file,
 			yyget_lineno(this->scanner),
-			this->linepos - yyget_leng(this->scanner),
-			yyget_leng(this->scanner)
+			this->linepos - static_cast<int>(yyget_leng(this->scanner)),
+			static_cast<int>(yyget_leng(this->scanner))
 		},
 		msg
 	};


### PR DESCRIPTION
Fix a build issue when building with auto-download in openage. C++11 sanitizer was even with `./configure --sanitizer none` not disabled for nyan and errored on narrowing from `long unsigned` to `int`.

Seen with clang 5.0.