### PR TITLE
Check compiler for C++17 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(BUILDSYSTEM_DIR "${nyan_SOURCE_DIR}/buildsystem")
 set(CMAKE_MODULE_PATH "${BUILDSYSTEM_DIR}")
 
 # load helper modules
+include(CheckCompilerFeatures)
 include(CMakePackageConfigHelpers)
 include(CTest)
 include(GenerateExportHeader)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,15 @@ set(nyan_exports_name "nyanTargets")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# CMake policies
+foreach(pol
+        CMP0067  # honor language standard in try_compile()
+       )
+	if (POLICY ${pol})
+		cmake_policy(SET ${pol} NEW)
+	endif()
+endforeach()
+
 # Ensure CMAKE_BUILD_TYPE is set correctly.
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Debug")

--- a/buildsystem/CheckCompilerFeatures.cmake
+++ b/buildsystem/CheckCompilerFeatures.cmake
@@ -1,0 +1,40 @@
+# Copyright 2018-2018 the nyan authors. See copying.md for legal info.
+
+cmake_policy(PUSH)
+
+if(POLICY CMP0067)
+	cmake_policy(SET CMP0067 NEW) # honor CXX_STANDARD in try_compile.
+endif()
+
+include(CheckCXXSourceCompiles)
+
+check_cxx_source_compiles("
+namespace nested::check {
+struct A {
+	int i;
+};
+} // namespace nested::check
+int main() {
+	nested::check::A a{10};
+	auto [i] = a;
+	return 10 - i;
+}
+"
+HAVE_REQUIRED_CXX17_SUPPORT
+)
+if(NOT HAVE_REQUIRED_CXX17_SUPPORT)
+	message(FATAL_ERROR "
+
+The compiler doesn't support required C++17 features:
+  * Nested namespace definition (N4230)
+  * Structured Bindings (P0217R3)
+The following versions support these features:
+  * clang++ >= 5
+  * g++ >= 7
+  * Microsoft Visual Studio 2017 >= 15.5
+Please upgrade your compiler to build nyan.
+
+")
+endif()
+
+cmake_policy(POP)

--- a/buildsystem/CheckCompilerFeatures.cmake
+++ b/buildsystem/CheckCompilerFeatures.cmake
@@ -1,11 +1,5 @@
 # Copyright 2018-2018 the nyan authors. See copying.md for legal info.
 
-cmake_policy(PUSH)
-
-if(POLICY CMP0067)
-	cmake_policy(SET CMP0067 NEW) # honor CXX_STANDARD in try_compile.
-endif()
-
 include(CheckCXXSourceCompiles)
 
 check_cxx_source_compiles("
@@ -36,5 +30,3 @@ Please upgrade your compiler to build nyan.
 
 ")
 endif()
-
-cmake_policy(POP)

--- a/nyan/CMakeLists.txt
+++ b/nyan/CMakeLists.txt
@@ -98,6 +98,12 @@ set_target_properties(nyan PROPERTIES
 	COMPATIBLE_INTERFACE_STRING nyan_MAJOR_VERSION
 )
 
+# C++ standard requirement
+target_compile_features(nyan
+	PUBLIC
+		cxx_std_17
+)
+
 # binaries
 install(
 	TARGETS nyan


### PR DESCRIPTION
Pull the compiler features check from openage.
Add the required feature as "[usage requirement](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#transitive-usage-requirements)" for nyan.