### PR TITLE
Fix Visual Studio build

### DIFF
--- a/nyan/config.h
+++ b/nyan/config.h
@@ -2,6 +2,11 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+// Allow using alternative operator representation with non-conforming compiler
+	#include <ciso646>
+#endif
+
 #include <cstddef>
 #include <limits>
 #include <string>

--- a/nyan/error.h
+++ b/nyan/error.h
@@ -5,6 +5,7 @@
 #include <exception>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/nyan/location.h
+++ b/nyan/location.h
@@ -1,7 +1,6 @@
 // Copyright 2016-2019 the nyan authors, LGPLv3+. See copying.md for legal info.
 #pragma once
 
-#include <ciso646>
 #include <memory>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Move `#include <ciso646>` to `config.h` which is included in all TUs.
Make it conditional for MSVC to limit the [impending deprecation warning/removal error in C++20](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0619r4.html).