### PR TITLE
Add missing cstddef include for size_t

### DIFF
--- a/nyan/datastructure/orderedset.h
+++ b/nyan/datastructure/orderedset.h
@@ -2,6 +2,7 @@
 #pragma once
 
 
+#include <cstddef>
 #include <list>
 #include <unordered_map>
 


### PR DESCRIPTION
`nyan` does not build on my system due to a missing include:

```
In file included from ../paru/clone/nyan-lang-git/src/nyan-lang-git/nyan/datastructure/orderedset.cpp:3:
../paru/clone/nyan-lang-git/src/nyan-lang-git/nyan/datastructure/orderedset.h:197:9: error: ‘size_t’ does not name a type
  197 |         size_t erase(const T &value) {
      |         ^~~~~~
../paru/clone/nyan-lang-git/src/nyan-lang-git/nyan/datastructure/orderedset.h:7:1: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
    6 | #include <unordered_map>
  +++ |+#include <cstddef>
    7 | 
../paru/clone/nyan-lang-git/src/nyan-lang-git/nyan/datastructure/orderedset.h:224:9: error: ‘size_t’ does not name a type
  224 |         size_t size() const {
      |         ^~~~~~
../paru/clone/nyan-lang-git/src/nyan-lang-git/nyan/datastructure/orderedset.h:224:9: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
make[2]: *** [nyan/CMakeFiles/nyan.dir/build.make:195: nyan/CMakeFiles/nyan.dir/datastructure/orderedset.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:879: nyan/CMakeFiles/nyan.dir/all] Error 2
make: *** [Makefile:146: all] Error 2

```