### PR TITLE
Fix missing include for g++-13

### DIFF
--- a/nyan/config.h
+++ b/nyan/config.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #pragma once
 
@@ -7,6 +7,7 @@
     #include <ciso646>
 #endif
 
+#include <cstdint>
 #include <cstddef>
 #include <limits>
 #include <string>


### PR DESCRIPTION
GCC 13 wants `cstdint` now for including fixed width integer types.

Closes https://github.com/SFTtech/nyan/issues/101