### PR TITLE
Fix Fiesta

### DIFF
--- a/nyan/ast.cpp
+++ b/nyan/ast.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2016-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "ast.h"
 
@@ -301,7 +301,9 @@ void ASTObject::ast_members(TokenStream &tokens) {
 			bool object_next = false;
 			auto lookahead = tokens.next();
 
-			if (lookahead->type == token_type::OPERATOR or lookahead->type == token_type::COLON) {
+			if (lookahead->type == token_type::OPERATOR  // value assignment
+				or lookahead->type == token_type::COLON  // type declaration
+				or lookahead->type == token_type::DOT) { // inherited member access (e.g. Parent.some_member)
 				object_next = false;
 			}
 			else if (lookahead->type == token_type::LANGLE or lookahead->type == token_type::LBRACKET or lookahead->type == token_type::LPAREN) {

--- a/nyan/ast.cpp
+++ b/nyan/ast.cpp
@@ -342,6 +342,10 @@ void ASTObject::ast_members(TokenStream &tokens) {
 
 		token = tokens.next();
 	}
+
+	if (token->type == token_type::ENDFILE) {
+		tokens.reinsert_last();
+	}
 }
 
 

--- a/nyan/config.h
+++ b/nyan/config.h
@@ -29,6 +29,9 @@ constexpr const order_t LATEST_T = std::numeric_limits<order_t>::max();
 /** fully-qualified object name */
 using fqon_t = std::string;
 
+/** fully-qualified namespace name */
+using fqnn_t = fqon_t;
+
 /** member name identifier type */
 using memberid_t = std::string;
 

--- a/nyan/database.cpp
+++ b/nyan/database.cpp
@@ -218,7 +218,7 @@ void Database::load(const std::string &filename,
 			throw InternalError{"object info could not be retrieved"};
 		}
 
-		info->update_children(std::move(children));
+		info->add_children(std::move(children));
 	}
 
 	for (auto loaded: imports) {

--- a/nyan/database.cpp
+++ b/nyan/database.cpp
@@ -377,7 +377,7 @@ void Database::find_member(bool skip_first,
 
 	// if the member is inherited, it can be prefixed with the ID
 	// of the object it's inherited from, e.g. ParentObj.some_member
-	std::string member_name = member_id;
+	memberid_t member_name = member_id;
 	std::optional<fqon_t> member_obj_id = std::nullopt;
 	std::vector<std::string> member_parts = util::split(member_id, '.');
 	if (member_parts.size() > 1) {
@@ -814,12 +814,26 @@ void Database::check_hierarchy(const std::vector<fqon_t> &new_objs,
 
 			for (auto &it : state_members) {
 				const memberid_t &member_id = it.first;
+
+				// if the member is inherited, its ID can be prefixed with the ID
+				// of the object it's inherited from, e.g. ParentObj.some_member
+				memberid_t member_name = member_id;
+				std::optional<fqon_t> member_obj_id = std::nullopt;
+				std::vector<std::string> member_parts = util::split(member_id, '.');
+				if (member_parts.size() > 1) {
+					member_name = member_parts.back();
+					member_parts.pop_back();
+
+					// TODO: resolve aliases here
+					member_obj_id = util::strjoin(".", member_parts);
+				}
+
 				const Member &member = it.second;
 				nyan_op op = member.get_operation();
 
 				// member has = operation, so it's no longer pending.
 				if (op == nyan_op::ASSIGN) {
-					pending_members.erase(member_id);
+					pending_members.erase(member_name);
 				}
 			}
 		}

--- a/nyan/database.cpp
+++ b/nyan/database.cpp
@@ -218,7 +218,7 @@ void Database::load(const std::string &filename,
 			throw InternalError{"object info could not be retrieved"};
 		}
 
-		info->set_children(std::move(children));
+		info->update_children(std::move(children));
 	}
 
 	for (auto loaded: imports) {
@@ -291,11 +291,14 @@ void Database::create_obj_content(std::vector<fqon_t> *new_objs,
 		fqon_t parent_id = scope.find(ns, parent, this->meta_info);
 
 		// this object is therefore a child of the parent one.
-		auto ins = child_assignments->emplace(
-			parent_id,
-			std::unordered_set<fqon_t>{}
-		);
-		ins.first->second.insert(obj_fqon);
+		auto ins = child_assignments->find(parent_id);
+		if (ins == std::end(*child_assignments)) {
+			ins = child_assignments->emplace(
+				parent_id,
+				std::unordered_set<fqon_t>{}
+			).first;
+		}
+		ins->second.insert(obj_fqon);
 
 		object_parents.push_back(std::move(parent_id));
 	}

--- a/nyan/database.cpp
+++ b/nyan/database.cpp
@@ -402,9 +402,10 @@ void Database::find_member(bool skip_first,
 		}
 
 		// TODO: if the obj fqon is prefixed, we can skip objects that don't match
-		if (member_obj_id and member_obj_id != obj) {
-			// continue;
-		}
+		// TODO: This requires that aliases and fqons are properly resolved
+		// if (member_obj_id and member_obj_id != obj) {
+		// 	continue;
+		// }
 
 		ObjectInfo *obj_info = this->meta_info.get_object(obj);
 		if (unlikely(obj_info == nullptr)) {
@@ -416,6 +417,7 @@ void Database::find_member(bool skip_first,
 		if (not obj_member_info) {
 			// TODO: fail here if the member is prefixed with the parent fqon
 			// but the object doesn't have the member
+			// TODO: This requires that aliases and fqons are properly resolved
 			// if (unlikely(member_obj_id)) {
 			// 	throw InternalError{"specified parent object doesn't have the member"};
 			// }

--- a/nyan/meta_info.cpp
+++ b/nyan/meta_info.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "meta_info.h"
 
@@ -50,6 +50,27 @@ bool MetaInfo::has_object(const fqon_t &name) const {
 	return this->object_info.count(name) == 1;
 }
 
+Namespace &MetaInfo::add_namespace(const Namespace &ns) {
+    auto ret = this->namespaces.insert({ns.to_fqon(), ns});
+
+	return ret.first->second;
+}
+
+Namespace *MetaInfo::get_namespace(const fqon_t &name) {
+    return const_cast<Namespace *>(std::as_const(*this).get_namespace(name));
+}
+
+const Namespace *MetaInfo::get_namespace(const fqon_t &name) const {
+	auto it = this->namespaces.find(name);
+	if (it == std::end(this->namespaces)) {
+		return nullptr;
+	}
+	return &it->second;
+}
+
+bool MetaInfo::has_namespace(const fqon_t &name) const {
+    return this->namespaces.contains(name);
+}
 
 std::string MetaInfo::str() const {
 	std::ostringstream builder;

--- a/nyan/meta_info.cpp
+++ b/nyan/meta_info.cpp
@@ -51,16 +51,16 @@ bool MetaInfo::has_object(const fqon_t &name) const {
 }
 
 Namespace &MetaInfo::add_namespace(const Namespace &ns) {
-    auto ret = this->namespaces.insert({ns.to_fqon(), ns});
+    auto ret = this->namespaces.insert({fqnn_t(ns.to_fqon()), ns});
 
 	return ret.first->second;
 }
 
-Namespace *MetaInfo::get_namespace(const fqon_t &name) {
+Namespace *MetaInfo::get_namespace(const fqnn_t &name) {
     return const_cast<Namespace *>(std::as_const(*this).get_namespace(name));
 }
 
-const Namespace *MetaInfo::get_namespace(const fqon_t &name) const {
+const Namespace *MetaInfo::get_namespace(const fqnn_t &name) const {
 	auto it = this->namespaces.find(name);
 	if (it == std::end(this->namespaces)) {
 		return nullptr;
@@ -68,7 +68,7 @@ const Namespace *MetaInfo::get_namespace(const fqon_t &name) const {
 	return &it->second;
 }
 
-bool MetaInfo::has_namespace(const fqon_t &name) const {
+bool MetaInfo::has_namespace(const fqnn_t &name) const {
     return this->namespaces.contains(name);
 }
 

--- a/nyan/meta_info.h
+++ b/nyan/meta_info.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 #pragma once
 
 #include <memory>
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include "object_info.h"
+#include "namespace.h"
 
 
 namespace nyan {
@@ -18,6 +19,7 @@ namespace nyan {
 class MetaInfo {
 public:
 	using obj_info_t = std::unordered_map<fqon_t, ObjectInfo>;
+	using ns_info_t = std::unordered_map<fqon_t, Namespace>;
 
 	MetaInfo() = default;
 	~MetaInfo() = default;
@@ -70,6 +72,42 @@ public:
 	bool has_object(const fqon_t &name) const;
 
 	/**
+	 * Add a namespace to the database.
+	 *
+	 * @param ns Namespace to add.
+	 *
+	 * @return The stored namespace.
+	 */
+	Namespace &add_namespace(const Namespace &ns);
+
+	/**
+	 * Get a namespace from the database.
+	 *
+	 * @param name Identifier of the namespace.
+	 *
+	 * @return The stored namespace.
+	 */
+	Namespace *get_namespace(const fqon_t &name);
+
+	/**
+	 * Get a namespace from the database.
+	 *
+	 * @param name Identifier of the namespace.
+	 *
+	 * @return The stored namespace.
+	 */
+	const Namespace *get_namespace(const fqon_t &name) const;
+
+	/**
+	 * Check if a namespace is in the database.
+	 *
+	 * @param name Identifier of the namespace.
+	 *
+	 * @return true if the namespace is in the database, else false.
+	 */
+	bool has_namespace(const fqon_t &name) const;
+
+	/**
 	 * Get a string representation of all metadata information objects.
 	 *
 	 * @return String representation of all metadata information objects.
@@ -82,6 +120,11 @@ protected:
 	 * This is for displaying error messages and line information.
 	 */
 	obj_info_t object_info;
+
+	/**
+	 * Namespaces loaded in the database.
+	 */
+	ns_info_t namespaces;
 };
 
 } // namespace nyan

--- a/nyan/meta_info.h
+++ b/nyan/meta_info.h
@@ -19,7 +19,7 @@ namespace nyan {
 class MetaInfo {
 public:
 	using obj_info_t = std::unordered_map<fqon_t, ObjectInfo>;
-	using ns_info_t = std::unordered_map<fqon_t, Namespace>;
+	using ns_info_t = std::unordered_map<fqnn_t, Namespace>;
 
 	MetaInfo() = default;
 	~MetaInfo() = default;
@@ -87,7 +87,7 @@ public:
 	 *
 	 * @return The stored namespace.
 	 */
-	Namespace *get_namespace(const fqon_t &name);
+	Namespace *get_namespace(const fqnn_t &name);
 
 	/**
 	 * Get a namespace from the database.
@@ -96,7 +96,7 @@ public:
 	 *
 	 * @return The stored namespace.
 	 */
-	const Namespace *get_namespace(const fqon_t &name) const;
+	const Namespace *get_namespace(const fqnn_t &name) const;
 
 	/**
 	 * Check if a namespace is in the database.
@@ -105,7 +105,7 @@ public:
 	 *
 	 * @return true if the namespace is in the database, else false.
 	 */
-	bool has_namespace(const fqon_t &name) const;
+	bool has_namespace(const fqnn_t &name) const;
 
 	/**
 	 * Get a string representation of all metadata information objects.

--- a/nyan/namespace.cpp
+++ b/nyan/namespace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2016-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "namespace.h"
 
@@ -94,9 +94,30 @@ Namespace Namespace::from_filename(const std::string &filename) {
 		throw APIError{"there's too many dots in the path"};
 	}
 
-	// strip off the file extension
-	std::string namespace_name{filename, 0, filename.size() - extension.size()};
-	std::replace(namespace_name.begin(), namespace_name.end(), '/', '.');
+	// sanitize the filename
+	// TODO: Do this via a file API
+	std::string namespace_name;
+	char prev_char;
+	char cur_char;
+	// condition strips off file extension
+	for (size_t i = 0; i < filename.size() - extension.size(); ++i) {
+		cur_char = filename[i];
+		
+		// slashes get replaced with dots
+		if (cur_char == '/') {
+			// strip multiple slashes
+			if (prev_char == '/') {
+				continue;
+			}
+			namespace_name += '.';
+		}
+		// normal chars get copied
+		else {
+			namespace_name += cur_char;
+		}
+
+		prev_char = cur_char;
+	}
 
 	// the fqon_t constructor.
 	return Namespace{namespace_name};

--- a/nyan/object_info.cpp
+++ b/nyan/object_info.cpp
@@ -104,7 +104,7 @@ const std::vector<fqon_t> &ObjectInfo::get_linearization() const {
 }
 
 
-void ObjectInfo::update_children(std::unordered_set<fqon_t> &&children) {
+void ObjectInfo::add_children(std::unordered_set<fqon_t> &&children) {
 	this->initial_children.insert(children.begin(), children.end());
 }
 

--- a/nyan/object_info.cpp
+++ b/nyan/object_info.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "object_info.h"
 
@@ -101,6 +101,11 @@ void ObjectInfo::set_linearization(std::vector<fqon_t> &&lin) {
 
 const std::vector<fqon_t> &ObjectInfo::get_linearization() const {
 	return this->initial_linearization;
+}
+
+
+void ObjectInfo::update_children(std::unordered_set<fqon_t> &&children) {
+	this->initial_children.insert(children.begin(), children.end());
 }
 
 

--- a/nyan/object_info.h
+++ b/nyan/object_info.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
 #pragma once
 
 #include <unordered_map>
@@ -120,9 +120,16 @@ public:
 	const std::vector<fqon_t> &get_linearization() const;
 
 	/**
-	 * Set the initial children of the object at load time.
+	 * Update the children of the object.
 	 *
-	 * @param children List of initial children of the object.
+	 * @param children fqons of the child objects.
+	 */
+	void update_children(std::unordered_set<fqon_t> &&children);
+
+	/**
+	 * Set the children of the object.
+	 *
+	 * @param children fqons of the child objects.
 	 */
 	void set_children(std::unordered_set<fqon_t> &&children);
 

--- a/nyan/object_info.h
+++ b/nyan/object_info.h
@@ -120,11 +120,11 @@ public:
 	const std::vector<fqon_t> &get_linearization() const;
 
 	/**
-	 * Update the children of the object.
+	 * Add children to the object.
 	 *
-	 * @param children fqons of the child objects.
+	 * @param children fqons of the added child objects.
 	 */
-	void update_children(std::unordered_set<fqon_t> &&children);
+	void add_children(std::unordered_set<fqon_t> &&children);
 
 	/**
 	 * Set the children of the object.

--- a/test/test.nyan
+++ b/test/test.nyan
@@ -12,6 +12,7 @@ First():
     wat3 : optional(First) = Second
     wat4 : set(children(First)) = {Second}
     member : int = 15
+    nice_member : bool = True
     test : text = "rofl lol"
     bla : file = "wtf.h4x"
     blub : int = inf
@@ -25,6 +26,7 @@ FirstPatch<First>():
 
 Second(First):
     member *= 5.5
+    First.nice_member = False
     # nap : int
 
 NestingBase(First):

--- a/test/test.nyan
+++ b/test/test.nyan
@@ -34,8 +34,6 @@ NestingBase(First):
     setmember : set(int) = {1,2,3,4,
                             5,6,7,}
 
-    dictmember : dict(int, text) = {2: "two", 4: "four"}
-
     member = 2
 
     SomeChild(Dummy):
@@ -88,6 +86,11 @@ SetTest():
 SetPatch<SetTest>():
     member |= o{3,4,4}
     orderedmember += o{4}
+
+DictTest():
+    dictmember : dict(int, text) = {2: "two", 4: "four"}
+    dictmember2 : optional(dict(text, int)) = None
+    dictmember3 : optional(dict(text, int)) = {"two": 2, "four": 4}
 
 # importing!
 import imported as imp


### PR DESCRIPTION
* Keep track of imported namespaces (prevents errors for duplicate file/object loading)
* Allow inherited member IDs to be prefixed with the fqon of the object the memer is inherited from
* Fix a bug where nested objects before EOF crashed the parser
* Check if the value of an `optional` container is `None` before reading values