### PR TITLE
Use `clang-format` on entire code base

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,7 +81,7 @@ IndentCaseBlocks: false
 IndentCaseLabels: false
 IndentExternBlock: NoIndent
 IndentGotoLabels: false
-IndentPPDirectives: None
+IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 # clang-format-16 InsertNewlineAtEOF: true

--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignEscapedNewlines: DontAlign
 AlignOperands:   Align
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
@@ -100,7 +100,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
-ReflowComments: false
+ReflowComments: true
 SortIncludes:    CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignEscapedNewlines: DontAlign
 AlignOperands:   Align
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
@@ -100,7 +100,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
-ReflowComments: true
+ReflowComments: false
 SortIncludes:    CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/nyan/api_error.cpp
+++ b/nyan/api_error.cpp
@@ -20,9 +20,9 @@ MemberTypeError::MemberTypeError(const fqon_t &objname,
                                  const std::string &real_type,
                                  const std::string &wrong_type) :
 	APIError{(static_cast<const std::ostringstream &>(
-		          std::ostringstream{} << "type mismatch for member " << objname + "." << member
-		          << ": tried to convert real type " << real_type << " to " << wrong_type))
-	.str()},
+				  std::ostringstream{} << "type mismatch for member " << objname + "." << member
+									   << ": tried to convert real type " << real_type << " to " << wrong_type))
+                 .str()},
 	objname{objname},
 	member{member},
 	real_type{real_type},

--- a/nyan/api_error.h
+++ b/nyan/api_error.h
@@ -31,8 +31,10 @@ public:
  */
 class MemberTypeError : public APIError {
 public:
-	MemberTypeError(const fqon_t &objname, const memberid_t &member,
-	                const std::string &real_type, const std::string &wrong_type);
+	MemberTypeError(const fqon_t &objname,
+	                const memberid_t &member,
+	                const std::string &real_type,
+	                const std::string &wrong_type);
 
 protected:
 	/**

--- a/nyan/ast.cpp
+++ b/nyan/ast.cpp
@@ -282,8 +282,7 @@ void ASTObject::ast_parents(TokenStream &tokens) {
 			if (token.type != token_type::ID) {
 				throw ASTError{
 					"expected inheritance parent identifier, but there is",
-					token
-				};
+					token};
 			}
 
 			this->parents.emplace_back(token, stream);
@@ -301,9 +300,9 @@ void ASTObject::ast_members(TokenStream &tokens) {
 			bool object_next = false;
 			auto lookahead = tokens.next();
 
-			if (lookahead->type == token_type::OPERATOR  // value assignment
-				or lookahead->type == token_type::COLON  // type declaration
-				or lookahead->type == token_type::DOT) { // inherited member access (e.g. Parent.some_member)
+			if (lookahead->type == token_type::OPERATOR // value assignment
+			    or lookahead->type == token_type::COLON // type declaration
+			    or lookahead->type == token_type::DOT) { // inherited member access (e.g. Parent.some_member)
 				object_next = false;
 			}
 			else if (lookahead->type == token_type::LANGLE or lookahead->type == token_type::LBRACKET or lookahead->type == token_type::LPAREN) {
@@ -434,7 +433,6 @@ ASTMember::ASTMember(const Token &name,
 	name{IDToken{name, tokens}},
 	type{std::nullopt},
 	value{std::nullopt} {
-
 	auto token = tokens.next();
 	bool had_def_or_decl = false;
 
@@ -535,7 +533,6 @@ ASTMember::ASTMember(const Token &name,
 ASTMemberType::ASTMemberType(const Token &name,
                              TokenStream &tokens) :
 	name{IDToken{name, tokens}} {
-
 	// now there may follow type arguments, e.g.:
 	// set(arg, key=val)
 	// optional(dict(ktype, vtype))
@@ -547,7 +544,6 @@ ASTMemberType::ASTMemberType(const Token &name,
 	size_t num_expected_types = member_type.expected_nested_types();
 
 	if (token->type == token_type::LPAREN) {
-
 		// TODO: if we introduce optional arguments for composite types
 		// we have to adjust the allowed count here.
 		// or just count the non-kwarg arguments, and ignored the kwarg count.
@@ -561,18 +557,17 @@ ASTMemberType::ASTMemberType(const Token &name,
 			num_expected_types,
 			[this](const Token &token, TokenStream &stream) {
 				this->nested_types.emplace_back(token, stream);
-			}
-		);
+			});
 
 		if (unlikely(num_read_types != num_expected_types)) {
 			throw ASTError(
 				std::string("expected ")
-				+ std::to_string(num_expected_types)
-				+ " arguments for "
-				+ composite_type_to_string(member_type.composite_type)
-				+ " declaration, but only "
-				+ std::to_string(num_read_types)
-				+ " could be found",
+					+ std::to_string(num_expected_types)
+					+ " arguments for "
+					+ composite_type_to_string(member_type.composite_type)
+					+ " declaration, but only "
+					+ std::to_string(num_read_types)
+					+ " could be found",
 				*token,
 				false);
 		}
@@ -580,10 +575,10 @@ ASTMemberType::ASTMemberType(const Token &name,
 	else if (num_expected_types > 0) {
 		throw ASTError(
 			std::string("expected ")
-			+ std::to_string(num_expected_types)
-			+ " arguments for "
-			+ composite_type_to_string(member_type.composite_type)
-			+ " declaration",
+				+ std::to_string(num_expected_types)
+				+ " arguments for "
+				+ composite_type_to_string(member_type.composite_type)
+				+ " declaration",
 			*token,
 			false);
 	}
@@ -739,12 +734,11 @@ void ASTObject::strb(std::ostringstream &builder, int indentlevel) const {
 
 	// object parents
 	builder << "(";
-	util::strjoin(builder, ", ", this->parents,
-	              [](auto &stream, auto &elem) {
-		              stream << elem.str();
-	              });
+	util::strjoin(builder, ", ", this->parents, [](auto &stream, auto &elem) {
+		stream << elem.str();
+	});
 	builder << "):"
-	        << std::endl;
+			<< std::endl;
 
 	if (this->objects.size() > 0) {
 		for (auto &object : this->objects) {
@@ -795,8 +789,8 @@ void ASTMember::strb(std::ostringstream &builder, int indentlevel) const {
 
 	if (this->value.has_value()) {
 		builder << " "
-		        << op_to_string(this->operation)
-		        << " ";
+				<< op_to_string(this->operation)
+				<< " ";
 
 		this->value->strb(builder);
 	}
@@ -810,10 +804,9 @@ void ASTMemberType::strb(std::ostringstream &builder, int /*indentlevel*/) const
 
 	if (this->args.size() > 0) {
 		builder << "(";
-		util::strjoin(builder, ", ", this->args,
-		              [](auto &stream, auto& elem) {
-			              elem.strb(stream);
-		              });
+		util::strjoin(builder, ", ", this->args, [](auto &stream, auto &elem) {
+			elem.strb(stream);
+		});
 		builder << ")";
 	}
 }
@@ -846,8 +839,7 @@ void ASTMemberValue::strb(std::ostringstream &builder, int /*indentlevel*/) cons
 		throw InternalError{"unhandled container type"};
 	}
 
-	util::strjoin(builder, ", ", this->values,
-	              [](auto &stream, auto &elem) { stream << elem.str(); });
+	util::strjoin(builder, ", ", this->values, [](auto &stream, auto &elem) { stream << elem.str(); });
 
 	switch (this->composite_type) {
 	case composite_t::SET:
@@ -869,7 +861,7 @@ ASTError::ASTError(const std::string &msg,
 	if (add_token) {
 		std::ostringstream builder;
 		builder << msg << ": "
-		        << token_type_str(token.type);
+				<< token_type_str(token.type);
 		this->msg = std::move(builder).str();
 	}
 	else {
@@ -885,7 +877,7 @@ ASTError::ASTError(const std::string &msg,
 	if (add_token) {
 		std::ostringstream builder;
 		builder << msg << ": "
-		        << token_type_str(token.get_type());
+				<< token_type_str(token.get_type());
 		this->msg = builder.str();
 	}
 	else {

--- a/nyan/ast.h
+++ b/nyan/ast.h
@@ -38,7 +38,7 @@ unsigned int comma_list(token_type end,
                         TokenStream &tokens,
                         size_t limit,
                         const std::function<void(const Token &, TokenStream &)> &func,
-                        bool unlimited=false);
+                        bool unlimited = false);
 
 
 /**

--- a/nyan/basic_type.cpp
+++ b/nyan/basic_type.cpp
@@ -102,10 +102,8 @@ size_t BasicType::expected_nested_types() const {
 
 
 bool BasicType::operator==(const BasicType &other) const {
-	return (this->primitive_type == other.primitive_type and
-	        this->composite_type == other.composite_type);
+	return (this->primitive_type == other.primitive_type and this->composite_type == other.composite_type);
 }
-
 
 
 std::string BasicType::str() const {
@@ -130,22 +128,19 @@ BasicType BasicType::from_type_token(const IDToken &tok) {
 		{"text", primitive_t::TEXT},
 		{"file", primitive_t::FILENAME},
 		{"int", primitive_t::INT},
-		{"float", primitive_t::FLOAT}
-	};
+		{"float", primitive_t::FLOAT}};
 
 	// container type name map
 	static const std::unordered_map<std::string, composite_t> container_types = {
 		{"set", composite_t::SET},
 		{"orderedset", composite_t::ORDEREDSET},
-		{"dict", composite_t::DICT}
-	};
+		{"dict", composite_t::DICT}};
 
 	// modifier type name map
 	static const std::unordered_map<std::string, composite_t> modifiers = {
 		{"abstract", composite_t::ABSTRACT},
 		{"children", composite_t::CHILDREN},
-		{"optional", composite_t::OPTIONAL}
-	};
+		{"optional", composite_t::OPTIONAL}};
 
 	primitive_t type = primitive_t::OBJECT;
 	composite_t composite_type = composite_t::SINGLE;

--- a/nyan/c3.cpp
+++ b/nyan/c3.cpp
@@ -33,7 +33,6 @@ std::vector<fqon_t>
 linearize_recurse(const fqon_t &name,
                   const objstate_fetch_t &get_obj,
                   std::unordered_set<fqon_t> *seen) {
-
 	using namespace std::string_literals;
 
 	// test for inheritance loops
@@ -41,8 +40,7 @@ linearize_recurse(const fqon_t &name,
 		throw C3Error{
 			"recursive inheritance loop detected: '"s + name + "' already in {"
 			+ util::strjoin(", ", *seen)
-			+ "}"
-		};
+			+ "}"};
 	}
 	else {
 		seen->insert(name);
@@ -67,14 +65,12 @@ linearize_recurse(const fqon_t &name,
 	for (auto &parent : parents) {
 		// Recursive call to get the linearization of the parent
 		par_linearizations.push_back(
-			linearize_recurse(parent, get_obj, seen)
-		);
+			linearize_recurse(parent, get_obj, seen));
 	}
 
 	// And at the end, add all parents of this object to the merge-list.
 	par_linearizations.push_back(
-		{std::begin(parents), std::end(parents)}
-	);
+		{std::begin(parents), std::end(parents)});
 
 	// remove current name from the seen set
 	// we only needed it for the recursive call above.
@@ -109,7 +105,6 @@ linearize_recurse(const fqon_t &name,
 
 			// Test if the candidate is in any tail
 			for (size_t j = 0; j < par_linearizations.size(); j++) {
-
 				// The current list will never contain the candidate again.
 				if (j == i) {
 					continue;
@@ -121,7 +116,6 @@ linearize_recurse(const fqon_t &name,
 				// Start one slot after the head
 				// and check that the candidate is not in that tail.
 				for (size_t k = headpos_try + 1; k < tail.size(); k++) {
-
 					// The head is in that tail, so we fail
 					if (unlikely(*candidate == tail[k])) {
 						candidate_ok = false;
@@ -138,7 +132,8 @@ linearize_recurse(const fqon_t &name,
 			// The candidate was not in any tail
 			if (candidate_ok) {
 				break;
-			} else {
+			}
+			else {
 				// Try the next candidate,
 				// this means to select the next par_lin list.
 				continue;
@@ -171,8 +166,7 @@ linearize_recurse(const fqon_t &name,
 		if (not candidate_ok) {
 			throw C3Error{
 				"Can't find consistent C3 resolution order for "s
-				+ name + " for bases " + util::strjoin(", ", parents)
-			};
+				+ name + " for bases " + util::strjoin(", ", parents)};
 		}
 	}
 
@@ -181,8 +175,7 @@ linearize_recurse(const fqon_t &name,
 }
 
 
-C3Error::C3Error(const std::string &msg)
-	:
+C3Error::C3Error(const std::string &msg) :
 	Error{msg} {}
 
 

--- a/nyan/change_tracker.cpp
+++ b/nyan/change_tracker.cpp
@@ -25,10 +25,8 @@ ObjectChanges &ChangeTracker::track_patch(const fqon_t &target_name) {
 	// else: create a new one.
 	auto it = this->changes.find(target_name);
 	if (it == std::end(this->changes)) {
-		return this->changes.emplace(
-			target_name,
-			ObjectChanges{}
-		).first->second;
+		auto it_new_tracker = this->changes.emplace(target_name, ObjectChanges{}).first;
+		return it_new_tracker->second;
 	}
 	else {
 		return it->second;

--- a/nyan/change_tracker.h
+++ b/nyan/change_tracker.h
@@ -51,7 +51,6 @@ protected:
  */
 class ChangeTracker {
 public:
-
 	/**
 	 * Get the ObjectChanges for an object targeted by a patch
 	 * from the changes map or create a new one if there doesn't

--- a/nyan/compiler.h
+++ b/nyan/compiler.h
@@ -7,10 +7,10 @@
  * The expression is expected to be true (=likely) or false (=unlikely).
  */
 #if defined(__GNUC__)
-	#define likely(x)    __builtin_expect(!!(x), 1)
-	#define unlikely(x)  __builtin_expect(!!(x), 0)
+	#define likely(x) __builtin_expect(!!(x), 1)
+	#define unlikely(x) __builtin_expect(!!(x), 0)
 #else
-	#define likely(x)   (x)
+	#define likely(x) (x)
 	#define unlikely(x) (x)
 #endif
 
@@ -31,9 +31,9 @@
  */
 #if defined(_WIN32)
 	#if defined(nyan_EXPORTS)
-		#define NYANAPI __declspec(dllexport)     // library is built
+		#define NYANAPI __declspec(dllexport) // library is built
 	#else
-		#define NYANAPI __declspec(dllimport)     // library is used
+		#define NYANAPI __declspec(dllimport) // library is used
 	#endif /* nyan_EXPORTS */
 #else
 	#define NYANAPI __attribute__((visibility("default")))

--- a/nyan/config.h
+++ b/nyan/config.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #ifdef _MSC_VER
-// Allow using alternative operator representation with non-conforming compiler
-    #include <ciso646>
+	// Allow using alternative operator representation with non-conforming compiler
+	#include <ciso646>
 #endif
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <string>
 

--- a/nyan/curve.h
+++ b/nyan/curve.h
@@ -13,10 +13,9 @@
 
 namespace nyan {
 
-template<typename T>
+template <typename T>
 class Curve {
 public:
-
 	using container_t = std::map<order_t, T>;
 
 	using fallback_t = std::function<const T &(const order_t)>;
@@ -25,8 +24,7 @@ public:
 	Curve() {}
 
 #ifdef CURVE_FALLBACK_FUNCTION
-	Curve(const fallback_t &func)
-		:
+	Curve(const fallback_t &func) :
 		fallback{func} {}
 
 	/**
@@ -57,8 +55,7 @@ public:
 			else {
 #endif
 				throw InternalError{
-					"requested time lower than first curve entry"
-				};
+					"requested time lower than first curve entry"};
 #ifdef CURVE_FALLBACK_FUNCTION
 			}
 #endif

--- a/nyan/datastructure/orderedset.h
+++ b/nyan/datastructure/orderedset.h
@@ -25,7 +25,7 @@ public:
 		}
 	}
 
-	const OrderedSet &operator =(const OrderedSet &other) {
+	const OrderedSet &operator=(const OrderedSet &other) {
 		for (auto &value : other) {
 			this->insert(value);
 		}
@@ -34,7 +34,7 @@ public:
 	// no moves allowed because they invalidate
 	// the ordering iterators.
 	OrderedSet(OrderedSet &&other) = delete;
-	const OrderedSet &operator =(OrderedSet &&other) = delete;
+	const OrderedSet &operator=(OrderedSet &&other) = delete;
 
 	/**
 	 * Type of value contained in the set.
@@ -73,14 +73,13 @@ protected:
 	 */
 	class ConstIterator {
 	public:
-    	using iterator_category = std::forward_iterator_tag;
-    	using value_type = T;
-    	using difference_type = T;
-    	using pointer = T*;
-    	using reference = T&;
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = T;
+		using difference_type = T;
+		using pointer = T *;
+		using reference = T &;
 
-		ConstIterator(list_iter iter)
-			:
+		ConstIterator(list_iter iter) :
 			iter{iter} {}
 
 		virtual ~ConstIterator() = default;
@@ -88,7 +87,7 @@ protected:
 		/**
 		 * Advance the inner iterator to the next element.
 		 */
-		ConstIterator &operator ++() {
+		ConstIterator &operator++() {
 			++this->iter;
 			return *this;
 		}
@@ -99,7 +98,7 @@ protected:
 		 * Dereferencing it provides a pointer to the data.
 		 * Dereferencing that pointer gets the data reference.
 		 */
-		const T &operator *() const {
+		const T &operator*() const {
 			return *(*this->iter);
 		}
 
@@ -107,7 +106,7 @@ protected:
 		 * Check if this iterator points to the same element
 		 * as the other iterator.
 		 */
-		bool operator ==(const ConstIterator& other) const {
+		bool operator==(const ConstIterator &other) const {
 			return (this->iter == other.iter);
 		}
 
@@ -115,8 +114,8 @@ protected:
 		 * Check if the iterator does not point to the same
 		 * element as the other iterator.
 		 */
-		bool operator !=(const ConstIterator& other) const {
-			return not (*this == other);
+		bool operator!=(const ConstIterator &other) const {
+			return not(*this == other);
 		}
 
 	protected:
@@ -175,8 +174,7 @@ public:
 
 		// add a ptr to the value to the element order list at the end
 		auto list_ins = this->value_order.insert(
-			std::end(this->value_order), value_ptr
-		);
+			std::end(this->value_order), value_ptr);
 
 		// and store the list iterator to the map
 		value_pos->second = list_ins;

--- a/nyan/error.cpp
+++ b/nyan/error.cpp
@@ -5,13 +5,13 @@
 #include <memory>
 #include <sstream>
 #if defined(_WIN32) || defined(__CYGWIN__)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-// TODO - CaptureStackBackTrace doesn't report number of frames available
-// need to implement increase buffer size
-#define backtrace(buffer, buf_size) CaptureStackBackTrace(0, buf_size, buffer, NULL)
+	#define WIN32_LEAN_AND_MEAN
+	#include <windows.h>
+	// TODO - CaptureStackBackTrace doesn't report number of frames available
+	// need to implement increase buffer size
+	#define backtrace(buffer, buf_size) CaptureStackBackTrace(0, buf_size, buffer, NULL)
 #else
-#include <execinfo.h>
+	#include <execinfo.h>
 #endif
 
 #include "compiler.h"
@@ -42,7 +42,7 @@ void Backtrace::analyze() {
 }
 
 
-void Backtrace::get_symbols(std::function<void (const backtrace_symbol *)> cb, bool reversed) const {
+void Backtrace::get_symbols(std::function<void(const backtrace_symbol *)> cb, bool reversed) const {
 	backtrace_symbol symbol;
 
 	if (reversed) {
@@ -54,7 +54,8 @@ void Backtrace::get_symbols(std::function<void (const backtrace_symbol *)> cb, b
 
 			cb(&symbol);
 		}
-	} else {
+	}
+	else {
 		for (void *pc : this->stack_addrs) {
 			symbol.functionname = util::symbol_name(pc, false, true);
 			symbol.pc = pc;
@@ -87,12 +88,10 @@ bool Error::break_on_error = false;
 
 Error::Error(const std::string &msg,
              bool generate_backtrace,
-             bool store_cause)
-	:
+             bool store_cause) :
 	std::runtime_error{runtime_error_message},
 	backtrace{nullptr},
 	msg{msg} {
-
 	if (generate_backtrace) {
 		this->backtrace = std::make_shared<Backtrace>();
 		this->backtrace->analyze();
@@ -126,10 +125,12 @@ void Error::store_cause() {
 
 	try {
 		throw;
-	} catch (Error &cause) {
+	}
+	catch (Error &cause) {
 		cause.trim_backtrace();
 		this->cause = std::current_exception();
-	} catch (...) {
+	}
+	catch (...) {
 		this->cause = std::current_exception();
 	}
 }
@@ -169,29 +170,33 @@ void Error::enable_break(bool enable) {
 }
 
 
-std::ostream &operator <<(std::ostream &os, const Error &e) {
+std::ostream &operator<<(std::ostream &os, const Error &e) {
 	// output the exception cause
 	bool had_a_cause = true;
 	try {
 		e.rethrow_cause();
 		had_a_cause = false;
-	} catch (Error &cause) {
+	}
+	catch (Error &cause) {
 		os << cause << std::endl;
-	} catch (std::exception &cause) {
+	}
+	catch (std::exception &cause) {
 		os << util::demangle(typeid(cause).name()) << ": " << cause.what() << std::endl;
 	}
 
 	if (had_a_cause) {
 		os << std::endl
 		   << "The above exception was the direct cause "
-		      "of the following exception:"
-		   << std::endl << std::endl;
+			  "of the following exception:"
+		   << std::endl
+		   << std::endl;
 	}
 
 	// output the exception backtrace
 	if (e.get_backtrace()) {
 		os << *e.get_backtrace();
-	} else {
+	}
+	else {
 		os << "origin:" << std::endl;
 	}
 
@@ -205,13 +210,14 @@ std::ostream &operator <<(std::ostream &os, const Error &e) {
 /**
  * Prints a backtrace_symbol object.
  */
-std::ostream &operator <<(std::ostream &os, const backtrace_symbol &bt_sym) {
+std::ostream &operator<<(std::ostream &os, const backtrace_symbol &bt_sym) {
 	// imitate the looks of a Python traceback.
 	os << " -> ";
 
 	if (bt_sym.functionname.empty()) {
 		os << '?';
-	} else {
+	}
+	else {
 		os << bt_sym.functionname;
 	}
 
@@ -226,25 +232,24 @@ std::ostream &operator <<(std::ostream &os, const backtrace_symbol &bt_sym) {
 /**
  * Prints an entire Backtrace object.
  */
-std::ostream &operator <<(std::ostream &os, const Backtrace &bt) {
+std::ostream &operator<<(std::ostream &os, const Backtrace &bt) {
 	// imitate the looks of a Python traceback.
 	os << "Traceback (most recent call last):" << std::endl;
 
 	bt.get_symbols([&os](const backtrace_symbol *symbol) {
 		os << *symbol << std::endl;
-	}, true);
+	},
+	               true);
 
 	return os;
 }
 
 
-InternalError::InternalError(const std::string &msg)
-	:
+InternalError::InternalError(const std::string &msg) :
 	Error{msg} {}
 
 
-FileReadError::FileReadError(const std::string &msg)
-	:
+FileReadError::FileReadError(const std::string &msg) :
 	Error{msg} {}
 
 } // namespace nyan

--- a/nyan/error.h
+++ b/nyan/error.h
@@ -19,8 +19,8 @@ namespace nyan {
  * Backtrace::get_symbols().
  */
 struct backtrace_symbol {
-	std::string functionname;  // empty if unknown
-	void *pc;                  // nullptr if unknown
+	std::string functionname; // empty if unknown
+	void *pc; // nullptr if unknown
 };
 
 
@@ -50,8 +50,8 @@ public:
 	 * @param reversed
 	 *	  if true, the most recent call is given last.
 	 */
-	void get_symbols(std::function<void (const backtrace_symbol *)> cb,
-	                 bool reversed=true) const;
+	void get_symbols(std::function<void(const backtrace_symbol *)> cb,
+	                 bool reversed = true) const;
 
 	/**
 	 * Removes all the lower frames that are also present
@@ -77,8 +77,8 @@ protected:
 class Error : public std::runtime_error {
 public:
 	Error(const std::string &msg,
-	      bool generate_backtrace=true,
-	      bool store_cause=true);
+	      bool generate_backtrace = true,
+	      bool store_cause = true);
 
 	virtual ~Error() = default;
 
@@ -184,7 +184,7 @@ protected:
  * @param os Output stream the error is appended to.
  * @param e Error whose message is appended to the output stream.
  */
-std::ostream &operator <<(std::ostream &os, const Error &e);
+std::ostream &operator<<(std::ostream &os, const Error &e);
 
 
 /**
@@ -193,7 +193,7 @@ std::ostream &operator <<(std::ostream &os, const Error &e);
  * @param os Output stream the backtrace symbol is appended to.
  * @param bt_sym Backtrace symbol which is appended to the output stream.
  */
-std::ostream &operator <<(std::ostream &os, const backtrace_symbol &bt_sym);
+std::ostream &operator<<(std::ostream &os, const backtrace_symbol &bt_sym);
 
 
 /**
@@ -202,7 +202,7 @@ std::ostream &operator <<(std::ostream &os, const backtrace_symbol &bt_sym);
  * @param os Output stream the backtrace is appended to.
  * @param bt Backtrace which is appended to the output stream.
  */
-std::ostream &operator <<(std::ostream &os, const Backtrace &bt);
+std::ostream &operator<<(std::ostream &os, const Backtrace &bt);
 
 
 /**

--- a/nyan/file.cpp
+++ b/nyan/file.cpp
@@ -9,25 +9,21 @@
 namespace nyan {
 
 
-File::File(const std::string &virtual_name, std::string &&data)
-	:
+File::File(const std::string &virtual_name, std::string &&data) :
 	name{virtual_name},
 	data{std::move(data)} {
-
 	this->extract_lines();
 }
 
 
-File::File(const std::string &path)
-	:
+File::File(const std::string &path) :
 	File{path, util::read_file(path)} {
-
 	// util::read_file throws a FileReadError if unsuccessful.
 }
 
 
 void File::extract_lines() {
-	this->line_ends = { std::string::npos };
+	this->line_ends = {std::string::npos};
 
 	for (size_t i = 0; i < this->data.size(); i++) {
 		if (this->data[i] == '\n') {

--- a/nyan/file.h
+++ b/nyan/file.h
@@ -19,11 +19,11 @@ public:
 
 	// moving allowed
 	File(File &&other) noexcept = default;
-	File& operator =(File &&other) noexcept = default;
+	File &operator=(File &&other) noexcept = default;
 
 	// no copies
 	File(const File &other) = delete;
-	File &operator =(const File &other) = delete;
+	File &operator=(const File &other) = delete;
 
 	virtual ~File() = default;
 
@@ -96,4 +96,4 @@ protected:
 	std::vector<size_t> line_ends;
 };
 
-} // namespace std
+} // namespace nyan

--- a/nyan/inheritance_change.cpp
+++ b/nyan/inheritance_change.cpp
@@ -4,8 +4,7 @@
 
 namespace nyan {
 
-InheritanceChange::InheritanceChange(inher_change_t type, fqon_t &&target)
-	:
+InheritanceChange::InheritanceChange(inher_change_t type, fqon_t &&target) :
 	type{type},
 	target{std::move(target)} {}
 

--- a/nyan/inheritance_change.h
+++ b/nyan/inheritance_change.h
@@ -30,7 +30,6 @@ public:
 	const fqon_t &get_target() const;
 
 protected:
-
 	/**
 	 * Inheritance change type.
 	 */

--- a/nyan/lang_error.cpp
+++ b/nyan/lang_error.cpp
@@ -14,8 +14,7 @@ using namespace std::string_literals;
 
 LangError::LangError(const Location &location,
                      const std::string &msg,
-                     std::vector<std::pair<Location, std::string>> &&reasons)
-	:
+                     std::vector<std::pair<Location, std::string>> &&reasons) :
 	Error{msg},
 	location{location},
 	reasons{std::move(reasons)} {}
@@ -29,7 +28,7 @@ std::string LangError::str() const {
 	this->location.str(builder);
 
 	builder << "\x1b[31;1merror:\x1b[39;49m " << this->msg
-	        << "\x1b[0m";
+			<< "\x1b[0m";
 
 	return builder.str();
 }
@@ -47,8 +46,8 @@ static void visualize_location(std::ostringstream &builder, const Location &loca
 	}
 
 	builder << location.get_line_content() << std::endl
-	        << std::string(offset, ' ') << "\x1b[36;1m^"
-	        << std::string(length, '~') << "\x1b[m";
+			<< std::string(offset, ' ') << "\x1b[36;1m^"
+			<< std::string(length, '~') << "\x1b[m";
 }
 
 
@@ -66,13 +65,14 @@ std::string LangError::show_problem_origin() const {
 		const Location &loc = reason.first;
 		const std::string &msg = reason.second;
 
-		builder << std::endl << "\x1b[1m";
+		builder << std::endl
+				<< "\x1b[1m";
 
 		loc.str(builder);
 
 		builder << "\x1b[30;1mnote:\x1b[39;49m "
-		        << msg
-		        << "\x1b[0m" << std::endl;
+				<< msg
+				<< "\x1b[0m" << std::endl;
 
 		visualize_location(builder, loc);
 		builder << std::endl;
@@ -82,15 +82,13 @@ std::string LangError::show_problem_origin() const {
 }
 
 
-TypeError::TypeError(const Location &location, const std::string &msg)
-	:
+TypeError::TypeError(const Location &location, const std::string &msg) :
 	LangError{location, msg} {}
 
 
 NameError::NameError(const Location &location,
                      const std::string &msg,
-                     const std::string &name)
-	:
+                     const std::string &name) :
 	LangError{location, msg},
 	name{name} {}
 
@@ -115,7 +113,7 @@ std::string NameError::str() const {
 
 
 TokenizeError::TokenizeError(const Location &location,
-                             const std::string &msg):
+                             const std::string &msg) :
 	LangError{location, msg} {}
 
 } // namespace nyan

--- a/nyan/lang_error.h
+++ b/nyan/lang_error.h
@@ -15,8 +15,7 @@ namespace nyan {
  */
 class LangError : public Error {
 public:
-	LangError(const Location &location, const std::string &msg,
-	          std::vector<std::pair<Location, std::string>> &&reasons={});
+	LangError(const Location &location, const std::string &msg, std::vector<std::pair<Location, std::string>> &&reasons = {});
 
 	/**
 	 * String representation of this error.
@@ -34,7 +33,6 @@ public:
 	virtual std::string show_problem_origin() const;
 
 protected:
-
 	/**
 	 * Location of the error in a file.
 	 */
@@ -64,7 +62,8 @@ public:
 class NameError : public LangError {
 public:
 	NameError(const Location &location,
-	          const std::string &msg, const std::string &name="");
+	          const std::string &msg,
+	          const std::string &name = "");
 
 	/**
 	 * String representation of this error.
@@ -74,7 +73,6 @@ public:
 	std::string str() const override;
 
 protected:
-
 	/**
 	 * Name that the entitycausing this error conflicts with.
 	 */

--- a/nyan/lexer/bracket.cpp
+++ b/nyan/lexer/bracket.cpp
@@ -6,8 +6,7 @@
 namespace nyan::lexer {
 
 
-Bracket::Bracket(token_type ttype, int indent)
-	:
+Bracket::Bracket(token_type ttype, int indent) :
 	indentation{indent},
 	type{this->to_type(ttype)},
 	hanging{true} {}
@@ -57,7 +56,7 @@ std::string Bracket::get_closing_indent() const {
 	if (this->is_hanging()) {
 		std::ostringstream builder;
 		builder << "at least "
-		        << this->indentation;
+				<< this->indentation;
 		return builder.str();
 	}
 	else {

--- a/nyan/lexer/bracket.h
+++ b/nyan/lexer/bracket.h
@@ -10,54 +10,54 @@ namespace nyan::lexer {
 
 class Bracket {
 public:
-    Bracket(token_type type, int indent);
+	Bracket(token_type type, int indent);
 
-    /** This bracket is directly followed by a newline. */
-    void doesnt_hang(int hanging_indent);
+	/** This bracket is directly followed by a newline. */
+	void doesnt_hang(int hanging_indent);
 
-    /** Was this bracket not directly followed by a newline? */
-    bool is_hanging() const;
+	/** Was this bracket not directly followed by a newline? */
+	bool is_hanging() const;
 
-    /** Does this bracket match the given token type? */
-    bool matches(token_type type) const;
+	/** Does this bracket match the given token type? */
+	bool matches(token_type type) const;
 
-    /** Return the expected content indentation level. */
-    int get_content_indent() const;
+	/** Return the expected content indentation level. */
+	int get_content_indent() const;
 
-    /** Return the expected closing bracket indent level. */
-    std::string get_closing_indent() const;
+	/** Return the expected closing bracket indent level. */
+	std::string get_closing_indent() const;
 
-    /** Check if the closing indent is ok. */
-    bool closing_indent_ok(int indent) const;
+	/** Check if the closing indent is ok. */
+	bool closing_indent_ok(int indent) const;
 
-    /** Return the visual representation of the expected bracket */
-    const char *matching_type_str() const;
+	/** Return the visual representation of the expected bracket */
+	const char *matching_type_str() const;
 
-    /** convert the token type to bracket type */
-    static bracket_type to_type(token_type token);
+	/** convert the token type to bracket type */
+	static bracket_type to_type(token_type token);
 
 protected:
-    /** expected closing bracket type */
-    token_type expected_match() const;
+	/** expected closing bracket type */
+	token_type expected_match() const;
 
-    /**
+	/**
      * Indentation level of the line this bracket was in.
      */
-    int indentation;
+	int indentation;
 
-    /**
+	/**
      * Type of this opening bracket.
      */
-    bracket_type type;
+	bracket_type type;
 
-    /**
+	/**
      * true if the indentation mode is "hanging",
      * that is, if a continuation must happen at the
      * indent level of this opening bracket.
      * The expected indentation level of contained content is stored
      * in the `indentation` member.
      */
-    bool hanging;
+	bool hanging;
 };
 
 } // namespace nyan::lexer

--- a/nyan/lexer/impl.cpp
+++ b/nyan/lexer/impl.cpp
@@ -10,11 +10,9 @@
 
 namespace nyan::lexer {
 
-Impl::Impl(const std::shared_ptr<File> &file)
-	:
+Impl::Impl(const std::shared_ptr<File> &file) :
 	file{file},
 	input{file->get_content()} {
-
 	yylex_init_extra(this, &this->scanner);
 }
 
@@ -53,10 +51,8 @@ TokenizeError Impl::error(const std::string &msg) {
 			this->file,
 			yyget_lineno(this->scanner),
 			this->linepos - static_cast<int>(yyget_leng(this->scanner)),
-			static_cast<int>(yyget_leng(this->scanner))
-		},
-		msg
-	};
+			static_cast<int>(yyget_leng(this->scanner))},
+		msg};
 }
 
 void Impl::advance_linepos() {
@@ -105,8 +101,7 @@ void Impl::token(token_type type) {
 			token_start,
 			length,
 			type,
-			yyget_text(this->scanner)
-		});
+			yyget_text(this->scanner)});
 	}
 	else {
 		this->tokens.push(Token{
@@ -114,8 +109,7 @@ void Impl::token(token_type type) {
 			lineno,
 			token_start,
 			length,
-			type
-		});
+			type});
 	}
 }
 
@@ -124,30 +118,20 @@ void Impl::token(token_type type) {
  * so that the indentation can check if the depth is correct.
  */
 void Impl::track_brackets(token_type type, int token_start) {
-
 	// opening brackets
-	if (type == token_type::LPAREN or
-	    type == token_type::LANGLE or
-	    type == token_type::LBRACKET or
-	    type == token_type::LBRACE) {
-
+	if (type == token_type::LPAREN or type == token_type::LANGLE or type == token_type::LBRACKET or type == token_type::LBRACE) {
 		// Track bracket type and indentation.
 		// The position after the ( is exactly the expected indent
 		// for hanging brackets.
 		this->brackets.emplace(
 			type,
-			token_start + 1
-		);
+			token_start + 1);
 
 		this->possibly_hanging = true;
 		return;
 	}
 	// closing brackets
-	else if (type == token_type::RPAREN or
-	         type == token_type::RANGLE or
-	         type == token_type::RBRACKET or
-	         type == token_type::RBRACE) {
-
+	else if (type == token_type::RPAREN or type == token_type::RANGLE or type == token_type::RBRACKET or type == token_type::RBRACE) {
 		if (this->brackets.empty()) {
 			throw this->error("unexpected closing bracket, "
 			                  "as no opening one is known");
@@ -159,17 +143,17 @@ void Impl::track_brackets(token_type type, int token_start) {
 		if (not matching_open_bracket.matches(type)) {
 			std::ostringstream builder;
 			builder << "non-matching bracket: expected '"
-			        << matching_open_bracket.matching_type_str()
-			        << "' but got '" << token_type_str(type) << "'";
+					<< matching_open_bracket.matching_type_str()
+					<< "' but got '" << token_type_str(type) << "'";
 			throw this->error(builder.str());
 		}
 
 		if (not matching_open_bracket.closing_indent_ok(token_start)) {
 			std::ostringstream builder;
 			builder << "wrong indentation of bracket: expected "
-			        << matching_open_bracket.get_closing_indent()
-			        << " indentation spaces (it is currently at "
-			        << token_start << " spaces)";
+					<< matching_open_bracket.get_closing_indent()
+					<< " indentation spaces (it is currently at "
+					<< token_start << " spaces)";
 			throw this->error(builder.str());
 		}
 
@@ -179,23 +163,18 @@ void Impl::track_brackets(token_type type, int token_start) {
 	// newline directly after opening bracket
 	// means regular indentation has to follow
 	// and the bracket pair doesn't hang.
-	else if (not this->brackets.empty() and
-	         this->possibly_hanging and
-	         type == token_type::ENDLINE) {
-
+	else if (not this->brackets.empty() and this->possibly_hanging and type == token_type::ENDLINE) {
 		// the bracket is followed by a newline directly,
 		// thus is not hanging.
 		this->brackets.top().doesnt_hang(
-			this->previous_indent
-		);
+			this->previous_indent);
 	}
-	else if (not this->brackets.empty() and
-	         this->bracketcloseindent_expected) {
+	else if (not this->brackets.empty() and this->bracketcloseindent_expected) {
 		std::ostringstream builder;
 		builder << ("expected closing bracket or content "
 		            "at indentation with ")
-		        << this->brackets.top().get_content_indent()
-		        << " spaces (you start at " << token_start << " spaces)";
+				<< this->brackets.top().get_content_indent()
+				<< " spaces (you start at " << token_start << " spaces)";
 		throw this->error(builder.str());
 	}
 
@@ -206,7 +185,6 @@ void Impl::track_brackets(token_type type, int token_start) {
  * measure the indentation of a line
  */
 void Impl::handle_indent(int depth) {
-
 	this->linepos -= yyget_leng(this->scanner) - depth;
 
 	if (not this->brackets.empty()) {
@@ -233,8 +211,8 @@ void Impl::handle_indent(int depth) {
 	if ((depth % SPACES_PER_INDENT) > 0) {
 		std::ostringstream builder;
 		builder << "indentation requires exactly "
-		        << SPACES_PER_INDENT
-		        << " spaces per level";
+				<< SPACES_PER_INDENT
+				<< " spaces per level";
 		throw this->error(builder.str());
 	}
 

--- a/nyan/lexer/impl.h
+++ b/nyan/lexer/impl.h
@@ -4,8 +4,8 @@
 #include <queue>
 #include <stack>
 
-#include "bracket.h"
 #include "../lang_error.h"
+#include "bracket.h"
 
 
 namespace nyan::lexer {
@@ -13,24 +13,23 @@ namespace nyan::lexer {
 /// Interface with flex generated lexer.
 class Impl {
 public:
-
 	explicit Impl(const std::shared_ptr<File> &file);
 
 	~Impl();
 
 	/** No copies. No moves. */
 	Impl(const Impl &other) = delete;
-	Impl(Impl&& other) = delete;
-	const Impl &operator =(const Impl &other) = delete;
-	Impl &&operator =(Impl &&other) = delete;
+	Impl(Impl &&other) = delete;
+	const Impl &operator=(const Impl &other) = delete;
+	Impl &&operator=(Impl &&other) = delete;
 
 	/** Produce a token by reading the input. */
 	Token generate_token();
 
-/** @name FlexInterfaceMethods
+	/** @name FlexInterfaceMethods
  * Methods used by the flex generated lexer.
  */
-///@{
+	///@{
 
 	/** Advance the line position by match length. */
 	void advance_linepos();
@@ -56,10 +55,9 @@ public:
 	/** Generate indentation tokens based on given depth. */
 	void handle_indent(int depth);
 
-///@}
+	///@}
 
 protected:
-
 	/**
 	 * Indentation enforcement in parens requires to track
 	 * the open and closing parens `(<[{}]>)`.

--- a/nyan/lexer/lexer.cpp
+++ b/nyan/lexer/lexer.cpp
@@ -7,10 +7,8 @@
 
 namespace nyan {
 
-Lexer::Lexer(const std::shared_ptr<File> &file)
-	:
+Lexer::Lexer(const std::shared_ptr<File> &file) :
 	impl{std::make_unique<lexer::Impl>(file)} {
-
 }
 
 Lexer::~Lexer() = default;
@@ -22,8 +20,7 @@ Token Lexer::get_next_token() {
 
 
 LexerError::LexerError(const Location &location,
-                       const std::string &msg)
-	:
+                       const std::string &msg) :
 	LangError{location, msg} {}
 
 } // namespace nyan

--- a/nyan/lexer/lexer.h
+++ b/nyan/lexer/lexer.h
@@ -28,8 +28,8 @@ public:
 	// no moves and copies
 	Lexer(Lexer &&other) = delete;
 	Lexer(const Lexer &other) = delete;
-	Lexer &operator =(Lexer &&other) = delete;
-	Lexer &operator =(const Lexer &other) = delete;
+	Lexer &operator=(Lexer &&other) = delete;
+	Lexer &operator=(const Lexer &other) = delete;
 
 	/**
 	 * Return the next available token.

--- a/nyan/member.cpp
+++ b/nyan/member.cpp
@@ -15,16 +15,14 @@ namespace nyan {
 Member::Member(override_depth_t depth,
                nyan_op operation,
                Type declared_type,
-               ValueHolder &&value)
-	:
+               ValueHolder &&value) :
 	override_depth{depth},
 	operation{operation},
 	declared_type{declared_type},
 	value{std::move(value)} {}
 
 
-Member::Member(const Member &other)
-	:
+Member::Member(const Member &other) :
 	override_depth{other.override_depth},
 	operation{other.operation},
 	declared_type{other.declared_type},
@@ -39,13 +37,13 @@ Member::Member(Member &&other) noexcept
 	value{std::move(other.value)} {}
 
 
-Member &Member::operator =(const Member &other) {
+Member &Member::operator=(const Member &other) {
 	*this = Member{other};
 	return *this;
 }
 
 
-Member &Member::operator =(Member &&other) noexcept {
+Member &Member::operator=(Member &&other) noexcept {
 	this->override_depth = std::move(other.override_depth);
 	this->operation = std::move(other.operation);
 	this->value = std::move(other.value);

--- a/nyan/member.h
+++ b/nyan/member.h
@@ -30,8 +30,8 @@ public:
 
 	Member(const Member &other);
 	Member(Member &&other) noexcept;
-	Member &operator =(const Member &other);
-	Member &operator =(Member &&other) noexcept;
+	Member &operator=(const Member &other);
+	Member &operator=(Member &&other) noexcept;
 
 	~Member() = default;
 
@@ -67,7 +67,6 @@ public:
 	std::string str() const;
 
 protected:
-
 	/**
 	 * Number of @ chars before the operation,
 	 * those define the override depth when applying the patch.

--- a/nyan/member_info.cpp
+++ b/nyan/member_info.cpp
@@ -8,8 +8,7 @@
 
 namespace nyan {
 
-MemberInfo::MemberInfo(const Location &location)
-	:
+MemberInfo::MemberInfo(const Location &location) :
 	location{location},
 	initial_def{false} {}
 

--- a/nyan/meta_info.cpp
+++ b/nyan/meta_info.cpp
@@ -19,8 +19,7 @@ ObjectInfo &MetaInfo::add_object(const fqon_t &name, ObjectInfo &&obj_info) {
 		throw LangError{
 			loc,
 			"object already defined",
-			{{ret.first->second.get_location(), "first defined here"}}
-		};
+			{{ret.first->second.get_location(), "first defined here"}}};
 	}
 
 	return ret.first->second;
@@ -51,13 +50,13 @@ bool MetaInfo::has_object(const fqon_t &name) const {
 }
 
 Namespace &MetaInfo::add_namespace(const Namespace &ns) {
-    auto ret = this->namespaces.insert({fqnn_t(ns.to_fqon()), ns});
+	auto ret = this->namespaces.insert({fqnn_t(ns.to_fqon()), ns});
 
 	return ret.first->second;
 }
 
 Namespace *MetaInfo::get_namespace(const fqnn_t &name) {
-    return const_cast<Namespace *>(std::as_const(*this).get_namespace(name));
+	return const_cast<Namespace *>(std::as_const(*this).get_namespace(name));
 }
 
 const Namespace *MetaInfo::get_namespace(const fqnn_t &name) const {
@@ -69,7 +68,7 @@ const Namespace *MetaInfo::get_namespace(const fqnn_t &name) const {
 }
 
 bool MetaInfo::has_namespace(const fqnn_t &name) const {
-    return this->namespaces.contains(name);
+	return this->namespaces.contains(name);
 }
 
 std::string MetaInfo::str() const {

--- a/nyan/meta_info.h
+++ b/nyan/meta_info.h
@@ -2,12 +2,12 @@
 #pragma once
 
 #include <memory>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 #include "config.h"
-#include "object_info.h"
 #include "namespace.h"
+#include "object_info.h"
 
 
 namespace nyan {

--- a/nyan/namespace.cpp
+++ b/nyan/namespace.cpp
@@ -112,15 +112,13 @@ const std::vector<std::string> &Namespace::get_obj_components() const {
 std::string Namespace::to_dirpath() const {
 	return util::strjoin(
 		"/",
-		this->dir_components
-	);
+		this->dir_components);
 }
 
 std::string Namespace::to_filepath() const {
 	std::string ret = util::strjoin(
 		"/",
-		this->dir_components
-	);
+		this->dir_components);
 
 	if (not this->filename.empty()) {
 		ret += "/" + this->filename + extension;

--- a/nyan/nyan.h
+++ b/nyan/nyan.h
@@ -23,15 +23,15 @@
 #include "token.h"
 #include "type.h"
 #include "util.h"
-#include "value/value.h"
-#include "value/file.h"
 #include "value/container.h"
+#include "value/dict.h"
+#include "value/file.h"
 #include "value/number.h"
 #include "value/object.h"
 #include "value/orderedset.h"
 #include "value/set.h"
-#include "value/dict.h"
 #include "value/text.h"
+#include "value/value.h"
 #include "view.h"
 
 

--- a/nyan/nyan_tool.cpp
+++ b/nyan/nyan_tool.cpp
@@ -20,10 +20,9 @@ int test_parser(const std::string &base_path, const std::string &filename) {
 
 	db->load(
 		filename,
-		[&base_path] (const std::string &filename) {
+		[&base_path](const std::string &filename) {
 			return std::make_shared<File>(base_path + "/" + filename);
-		}
-	);
+		});
 
 	std::shared_ptr<View> root = db->new_view();
 
@@ -32,8 +31,8 @@ int test_parser(const std::string &base_path, const std::string &filename) {
 	Object first = root->get_object("test.First");
 
 	std::cout << "before change: First.member == "
-	          << *root->get_object("test.First").get<Int>("member")
-	          << std::endl;
+			  << *root->get_object("test.First").get<Int>("member")
+			  << std::endl;
 
 	std::optional<std::shared_ptr<Object>> wat3_first = first.get_optional<Object>("wat3", 0);
 	if (wat3_first.has_value()) {
@@ -78,8 +77,8 @@ int test_parser(const std::string &base_path, const std::string &filename) {
 	auto value = *root->get_object("test.First").get<Int>("member");
 
 	std::cout << "after change: First.member == "
-	          << value.str()
-	          << std::endl;
+			  << value.str()
+			  << std::endl;
 
 	if (value != 24) {
 		std::cout << "patch result is wrong" << std::endl;
@@ -126,32 +125,35 @@ int test_parser(const std::string &base_path, const std::string &filename) {
 	}
 
 	std::cout << "after change: Second.member == "
-	          << *second.get<Int>("member", 1)
-	          << std::endl;
+			  << *second.get<Int>("member", 1)
+			  << std::endl;
 
 	std::cout << "SetTest.member = "
-	          << root->get_object("test.SetTest").get_value("member")->str()
-	          << std::endl
-	          << "SetTest.orderedmember = "
-	          << root->get_object("test.SetTest").get_value("orderedmember")->str()
-	          << std::endl
-	          << "Fifth.truth = "
-	          << root->get_object("test.Fifth").get_value("truth")->str()
-	          << std::endl
-	          << "PATCH"
-	          << std::endl
-	          << "SetTest.member = "
-	          << root->get_object("test.SetTest").get_value("member", 1)->str()
-	          << std::endl
-	          << "SetTest.orderedmember = "
-	          << root->get_object("test.SetTest").get_value("orderedmember", 1)->str()
-	          << std::endl << std::endl;
+			  << root->get_object("test.SetTest").get_value("member")->str()
+			  << std::endl
+			  << "SetTest.orderedmember = "
+			  << root->get_object("test.SetTest").get_value("orderedmember")->str()
+			  << std::endl
+			  << "Fifth.truth = "
+			  << root->get_object("test.Fifth").get_value("truth")->str()
+			  << std::endl
+			  << "PATCH"
+			  << std::endl
+			  << "SetTest.member = "
+			  << root->get_object("test.SetTest").get_value("member", 1)->str()
+			  << std::endl
+			  << "SetTest.orderedmember = "
+			  << root->get_object("test.SetTest").get_value("orderedmember", 1)->str()
+			  << std::endl
+			  << std::endl;
 
 	std::cout << "test.gschicht parents = " << util::strjoin(", ", root->get_object("test.Test").get_parents())
-	          << std::endl << "PATCH" << std::endl
-	          << "test.gschicht parents = " << util::strjoin(", ", root->get_object("test.Test").get_parents(1))
-	          << std::endl << "newvalue = " << root->get_object("test.Test").get_value("new_value", 1)->str()
-	          << std::endl;
+			  << std::endl
+			  << "PATCH" << std::endl
+			  << "test.gschicht parents = " << util::strjoin(", ", root->get_object("test.Test").get_parents(1))
+			  << std::endl
+			  << "newvalue = " << root->get_object("test.Test").get_value("new_value", 1)->str()
+			  << std::endl;
 
 	return ret;
 }
@@ -180,20 +182,22 @@ int run(flags_t flags, params_t params) {
 			}
 			catch (LangError &err) {
 				std::cout << "\x1b[33;1mfile error:\x1b[m\n"
-				          << err << std::endl
-				          << err.show_problem_origin()
-				          << std::endl << std::endl;
+						  << err << std::endl
+						  << err.show_problem_origin()
+						  << std::endl
+						  << std::endl;
 				return 1;
 			}
 		}
 		else {
-			std::cout << "no action selected" << std::endl << std::endl;
+			std::cout << "no action selected" << std::endl
+					  << std::endl;
 			help();
 		}
 	}
 	catch (Error &err) {
 		std::cout << "\x1b[31;1merror:\x1b[m\n"
-		          << err << std::endl;
+				  << err << std::endl;
 		return 1;
 	}
 	return 0;
@@ -202,30 +206,29 @@ int run(flags_t flags, params_t params) {
 
 void help() {
 	std::cout << "\x1b[32;1mnyan\x1b[m - "
-	             "\x1b[32;1my\x1b[met "
-	             "\x1b[32;1ma\x1b[mnother "
-	             "\x1b[32;1mn\x1b[motation "
-	             "-- tool" << std::endl
-	          << std::endl
-	          << "usage:" << std::endl
-	          << "-h --help                  -- show this" << std::endl
-	          << "-f --file <filename>       -- file to load" << std::endl
-	          << "-b --break                 -- debug-break on error" << std::endl
-	          << "   --test-parser           -- test the parser" << std::endl
-	          << "   --echo                  -- print the ast" << std::endl
-	          << "" << std::endl;
+				 "\x1b[32;1my\x1b[met "
+				 "\x1b[32;1ma\x1b[mnother "
+				 "\x1b[32;1mn\x1b[motation "
+				 "-- tool"
+			  << std::endl
+			  << std::endl
+			  << "usage:" << std::endl
+			  << "-h --help                  -- show this" << std::endl
+			  << "-f --file <filename>       -- file to load" << std::endl
+			  << "-b --break                 -- debug-break on error" << std::endl
+			  << "   --test-parser           -- test the parser" << std::endl
+			  << "   --echo                  -- print the ast" << std::endl
+			  << "" << std::endl;
 }
 
 
-std::pair<flags_t, params_t> argparse(int argc, char** argv) {
+std::pair<flags_t, params_t> argparse(int argc, char **argv) {
 	flags_t flags{
 		{option_flag::ECHO, false},
-		{option_flag::TEST_PARSER, false}
-	};
+		{option_flag::TEST_PARSER, false}};
 
 	params_t params{
-		{option_param::FILE, ""}
-	};
+		{option_param::FILE, ""}};
 
 	for (int option_index = 1; option_index < argc; ++option_index) {
 		std::string arg = argv[option_index];
@@ -277,7 +280,7 @@ int main(int argc, char **argv) {
 	}
 	catch (std::exception &exc) {
 		std::cout << "\x1b[31;1mfatal error:\x1b[m "
-		          << exc.what() << std::endl;
+				  << exc.what() << std::endl;
 		return 1;
 	}
 #endif

--- a/nyan/nyan_tool.h
+++ b/nyan/nyan_tool.h
@@ -44,9 +44,9 @@ namespace std {
 /**
  * Hash for the option_flag enum class. Fak u C++!
  */
-template<>
+template <>
 struct hash<nyan::option_flag> {
-	size_t operator ()(const nyan::option_flag &x) const {
+	size_t operator()(const nyan::option_flag &x) const {
 		return static_cast<size_t>(x);
 	}
 };
@@ -54,9 +54,9 @@ struct hash<nyan::option_flag> {
 /**
  * Hash for the option_param enum class. Fak u C++!
  */
-template<>
+template <>
 struct hash<nyan::option_param> {
-	size_t operator ()(const nyan::option_param &x) const {
+	size_t operator()(const nyan::option_param &x) const {
 		return static_cast<size_t>(x);
 	}
 };

--- a/nyan/object.h
+++ b/nyan/object.h
@@ -12,11 +12,11 @@
 
 #include "api_error.h"
 #include "config.h"
-#include "value/none.h"
-#include "value/container_types.h"
-#include "value/value_holder.h"
 #include "object_notifier_types.h"
 #include "util.h"
+#include "value/container_types.h"
+#include "value/none.h"
+#include "value/value_holder.h"
 
 
 namespace nyan {
@@ -45,6 +45,7 @@ concept ValueLike = std::derived_from<T, Value> || std::is_same_v<T, Object>;
  */
 class Object {
 	friend class View;
+
 protected:
 	/**
 	 * Create a nyan-object handle. This is never invoked by the user,
@@ -62,8 +63,8 @@ public:
 	// This constructor is public, but can't be invoked since the Restricted
 	// class is not available. We use this to be able to invoke make_shared
 	// within this class, but not outside of it.
-	Object(Object::Restricted, const fqon_t &name, const std::shared_ptr<View> &origin)
-		: Object(name, origin) {};
+	Object(Object::Restricted, const fqon_t &name, const std::shared_ptr<View> &origin) :
+		Object(name, origin) {};
 	~Object();
 
 	/**
@@ -89,7 +90,7 @@ public:
 	 *
 	 * @return ValueHolder containing the raw value of the member.
 	 */
-	ValueHolder get_value(const memberid_t &member, order_t t=LATEST_T) const;
+	ValueHolder get_value(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value container for a given member at a given time.
@@ -105,7 +106,7 @@ public:
 	 * @return Value of the member.
 	 */
 	template <ValueLike T>
-	std::shared_ptr<T> get(const memberid_t &member, order_t t=LATEST_T) const;
+	std::shared_ptr<T> get(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value container for a given member at a given time.
@@ -118,8 +119,8 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	template <ValueLike T, bool may_be_none=true>
-	std::optional<std::shared_ptr<T>> get_optional(const memberid_t &member, order_t t=LATEST_T) const;
+	template <ValueLike T, bool may_be_none = true>
+	std::optional<std::shared_ptr<T>> get_optional(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for a number type member (\p int or \p float).
@@ -132,8 +133,8 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	template<std::derived_from<NumberBase> T, typename ret=typename T::storage_type>
-	ret get_number(const memberid_t &member, order_t t=LATEST_T) const;
+	template <std::derived_from<NumberBase> T, typename ret = typename T::storage_type>
+	ret get_number(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p int type member.
@@ -143,7 +144,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	value_int_t get_int(const memberid_t &member, order_t t=LATEST_T) const;
+	value_int_t get_int(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p float type member.
@@ -155,7 +156,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	value_float_t get_float(const memberid_t &member, order_t t=LATEST_T) const;
+	value_float_t get_float(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p text type member.
@@ -165,7 +166,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	std::string get_text(const memberid_t &member, order_t t=LATEST_T) const;
+	std::string get_text(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p bool type member.
@@ -175,7 +176,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	bool get_bool(const memberid_t &member, order_t t=LATEST_T) const;
+	bool get_bool(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p set type member.
@@ -185,7 +186,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	set_t get_set(const memberid_t &member, order_t t=LATEST_T) const;
+	set_t get_set(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p orderedset type member.
@@ -195,7 +196,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	ordered_set_t get_orderedset(const memberid_t &member, order_t t=LATEST_T) const;
+	ordered_set_t get_orderedset(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p dict type member.
@@ -205,7 +206,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	dict_t get_dict(const memberid_t &member, order_t t=LATEST_T) const;
+	dict_t get_dict(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for an \p file type member.
@@ -215,7 +216,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	std::string get_file(const memberid_t &member, order_t t=LATEST_T) const;
+	std::string get_file(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value container for an \p object type member.
@@ -225,7 +226,7 @@ public:
 	 *
 	 * @return Value of the member.
 	 */
-	Object get_object(const memberid_t &fqon, order_t t=LATEST_T) const;
+	Object get_object(const memberid_t &fqon, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the parents of this object at a given time.
@@ -234,7 +235,7 @@ public:
 	 *
 	 * @return Double-linked queue containing the parents of this object.
 	 */
-	const std::deque<fqon_t> &get_parents(order_t t=LATEST_T) const;
+	const std::deque<fqon_t> &get_parents(order_t t = LATEST_T) const;
 
 	/**
 	 * Test if this object has a member with a given name at a given time.
@@ -244,7 +245,7 @@ public:
 	 *
 	 * @return true if the member exists for this object, else false.
 	 */
-	bool has(const memberid_t &member, order_t t=LATEST_T) const;
+	bool has(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * Check if this object is a child of the given parent at a given time.
@@ -256,7 +257,7 @@ public:
 	 *     identifier or that of any of its (transitive) parents,
 	 *     else false
 	 */
-	bool extends(fqon_t other_fqon, order_t t=LATEST_T) const;
+	bool extends(fqon_t other_fqon, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the metadata information object for this object.
@@ -287,7 +288,7 @@ public:
 	 *
 	 * @return C3 linearization of this object.
 	 */
-	const std::vector<fqon_t> &get_linearized(order_t t=LATEST_T) const;
+	const std::vector<fqon_t> &get_linearized(order_t t = LATEST_T) const;
 
 	/**
 	 * Register a function that will be called when this object changes in its current view.
@@ -303,7 +304,6 @@ public:
 	std::shared_ptr<ObjectNotifier> subscribe(const update_cb_t &callback);
 
 protected:
-
 	/**
 	 * Get the object state at a given time.
 	 *
@@ -311,7 +311,7 @@ protected:
 	 *
 	 * @return Shared pointer to the object state.
 	 */
-	const std::shared_ptr<ObjectState> &get_raw(order_t t=LATEST_T) const;
+	const std::shared_ptr<ObjectState> &get_raw(order_t t = LATEST_T) const;
 
 	/**
 	 * Get the calculated member value for a given member at a given time.
@@ -321,7 +321,7 @@ protected:
 	 *
 	 * @return ValueHolder with the value of the member.
 	 */
-	ValueHolder calculate_value(const memberid_t &member, order_t t=LATEST_T) const;
+	ValueHolder calculate_value(const memberid_t &member, order_t t = LATEST_T) const;
 
 	/**
 	 * View the object was created from.
@@ -358,15 +358,14 @@ std::optional<std::shared_ptr<T>> Object::get_optional(const memberid_t &member,
 			this->name,
 			member,
 			util::typestring(value.get()),
-			util::typestring<T>()
-		};
+			util::typestring<T>()};
 	}
 
 	return ret;
 }
 
 
-template<std::derived_from<NumberBase> T, typename ret>
+template <std::derived_from<NumberBase> T, typename ret>
 ret Object::get_number(const memberid_t &member, order_t t) const {
 	return *this->get<T>(member, t);
 }

--- a/nyan/object_notifier.cpp
+++ b/nyan/object_notifier.cpp
@@ -7,8 +7,7 @@
 
 namespace nyan {
 
-ObjectNotifierHandle::ObjectNotifierHandle(const update_cb_t &func)
-	:
+ObjectNotifierHandle::ObjectNotifierHandle(const update_cb_t &func) :
 	func{func} {}
 
 
@@ -19,8 +18,7 @@ void ObjectNotifierHandle::fire(order_t t, const fqon_t &fqon, const ObjectState
 
 ObjectNotifier::ObjectNotifier(const fqon_t &fqon,
                                const update_cb_t &func,
-                               const std::shared_ptr<View> &view)
-	:
+                               const std::shared_ptr<View> &view) :
 	fqon{fqon},
 	view{view},
 	handle{std::make_shared<ObjectNotifierHandle>(func)} {}

--- a/nyan/object_notifier.h
+++ b/nyan/object_notifier.h
@@ -38,7 +38,6 @@ protected:
 
 class ObjectNotifier {
 public:
-
 	ObjectNotifier(const fqon_t &fqon,
 	               const update_cb_t &func,
 	               const std::shared_ptr<View> &view);

--- a/nyan/object_state.cpp
+++ b/nyan/object_state.cpp
@@ -14,26 +14,21 @@
 namespace nyan {
 
 
-ObjectState::ObjectState(std::deque<fqon_t> &&parents)
-	:
+ObjectState::ObjectState(std::deque<fqon_t> &&parents) :
 	parents{std::move(parents)} {}
 
 
 void ObjectState::apply(const std::shared_ptr<ObjectState> &mod,
                         const ObjectInfo &mod_info,
                         ObjectChanges &tracker) {
-
 	const auto &inher_changes = mod_info.get_inheritance_change();
 	if (inher_changes.size() > 0) {
 		for (auto &change : inher_changes) {
-
-			bool parent_exists = (
-				std::find(
-					std::begin(this->parents),
-					std::end(this->parents),
-					change.get_target()
-				) != std::end(this->parents)
-			);
+			// check if the object already has the parent
+			auto it = std::find(std::begin(this->parents),
+			                    std::end(this->parents),
+			                    change.get_target());
+			bool parent_exists = it != std::end(this->parents);
 
 			// only add the parent if it does not exist.
 			// maybe we may want to relocate it in the future?
@@ -68,8 +63,7 @@ void ObjectState::apply(const std::shared_ptr<ObjectState> &mod,
 			}
 			else {
 				throw InternalError{
-					"a non-patch tried to change a nonexisting member"
-				};
+					"a non-patch tried to change a nonexisting member"};
 			}
 		}
 		else {
@@ -125,9 +119,9 @@ std::string ObjectState::str() const {
 	std::ostringstream builder;
 
 	builder << "ObjectState("
-	        << util::strjoin(", ", this->parents)
-	        << ")"
-	        << std::endl;
+			<< util::strjoin(", ", this->parents)
+			<< ")"
+			<< std::endl;
 
 	if (this->members.size() == 0) {
 		builder << "    [no members]" << std::endl;
@@ -135,7 +129,7 @@ std::string ObjectState::str() const {
 
 	for (auto &it : this->members) {
 		builder << "    " << it.first
-		        << " -> " << it.second.str() << std::endl;
+				<< " -> " << it.second.str() << std::endl;
 	}
 
 	return builder.str();

--- a/nyan/object_state.h
+++ b/nyan/object_state.h
@@ -19,6 +19,7 @@ class ObjectInfo;
  */
 class ObjectState {
 	friend class Database;
+
 public:
 	/**
 	 * Creation of an initial object state.

--- a/nyan/ops.cpp
+++ b/nyan/ops.cpp
@@ -30,7 +30,8 @@ nyan_op op_from_string(const std::string &str) {
 
 	if (it == std::end(str_to_op)) {
 		return nyan_op::INVALID;
-	} else {
+	}
+	else {
 		return it->second;
 	}
 }
@@ -46,8 +47,7 @@ nyan_op op_from_token(const Token &token) {
 }
 
 
-Operator::Operator(const Token &token)
-	:
+Operator::Operator(const Token &token) :
 	op{op_from_token(token)} {}
 
 

--- a/nyan/ops.h
+++ b/nyan/ops.h
@@ -58,18 +58,30 @@ extern const std::unordered_set<nyan_op> no_nyan_ops;
  */
 constexpr const char *op_to_string(nyan_op op) {
 	switch (op) {
-	case nyan_op::ADD:                return "+";
-	case nyan_op::ADD_ASSIGN:         return "+=";
-	case nyan_op::ASSIGN:             return "=";
-	case nyan_op::DIVIDE:             return "/";
-	case nyan_op::DIVIDE_ASSIGN:      return "/=";
-	case nyan_op::INTERSECT_ASSIGN:   return "&=";
-	case nyan_op::INVALID:            return "=INVALID=";
-	case nyan_op::MULTIPLY:           return "*";
-	case nyan_op::MULTIPLY_ASSIGN:    return "*=";
-	case nyan_op::SUBTRACT:           return "-";
-	case nyan_op::SUBTRACT_ASSIGN:    return "-=";
-	case nyan_op::UNION_ASSIGN:       return "|=";
+	case nyan_op::ADD:
+		return "+";
+	case nyan_op::ADD_ASSIGN:
+		return "+=";
+	case nyan_op::ASSIGN:
+		return "=";
+	case nyan_op::DIVIDE:
+		return "/";
+	case nyan_op::DIVIDE_ASSIGN:
+		return "/=";
+	case nyan_op::INTERSECT_ASSIGN:
+		return "&=";
+	case nyan_op::INVALID:
+		return "=INVALID=";
+	case nyan_op::MULTIPLY:
+		return "*";
+	case nyan_op::MULTIPLY_ASSIGN:
+		return "*=";
+	case nyan_op::SUBTRACT:
+		return "-";
+	case nyan_op::SUBTRACT_ASSIGN:
+		return "-=";
+	case nyan_op::UNION_ASSIGN:
+		return "|=";
 	}
 	return "unhandled nyan_op";
 }
@@ -119,9 +131,9 @@ namespace std {
 /**
  * Hash for the nyan_op enum class. Thanks C++!
  */
-template<>
+template <>
 struct hash<nyan::nyan_op> {
-	size_t operator ()(const nyan::nyan_op &x) const {
+	size_t operator()(const nyan::nyan_op &x) const {
 		return static_cast<size_t>(x);
 	}
 };

--- a/nyan/parser.cpp
+++ b/nyan/parser.cpp
@@ -12,11 +12,11 @@
 #include "token.h"
 #include "type.h"
 #include "util.h"
-#include "value/value.h"
 #include "value/number.h"
 #include "value/orderedset.h"
 #include "value/set.h"
 #include "value/text.h"
+#include "value/value.h"
 
 
 namespace nyan {
@@ -25,43 +25,43 @@ Parser::Parser() = default;
 
 
 AST Parser::parse(const std::shared_ptr<File> &file) {
-    // If you are some parser junkie and I trigger your rage mode now,
-    // feel free to rewrite the parser or use a tool like bison.
+	// If you are some parser junkie and I trigger your rage mode now,
+	// feel free to rewrite the parser or use a tool like bison.
 
-    // tokenize input
-    std::vector<Token> tokens = this->tokenize(file);
+	// tokenize input
+	std::vector<Token> tokens = this->tokenize(file);
 
-    // create ast from tokens
-    AST ast = this->create_ast(tokens);
+	// create ast from tokens
+	AST ast = this->create_ast(tokens);
 
-    return ast;
+	return ast;
 }
 
 
 std::vector<Token> Parser::tokenize(const std::shared_ptr<File> &file) const {
-    Lexer lexer{file};
+	Lexer lexer{file};
 
-    std::vector<Token> ret;
+	std::vector<Token> ret;
 
-    while (true) {
-        Token token = lexer.get_next_token();
-        bool end = (token.type == token_type::ENDFILE);
+	while (true) {
+		Token token = lexer.get_next_token();
+		bool end = (token.type == token_type::ENDFILE);
 
-        ret.push_back(std::move(token));
+		ret.push_back(std::move(token));
 
-        if (end) {
-            break;
-        }
-    }
+		if (end) {
+			break;
+		}
+	}
 
-    return ret;
+	return ret;
 }
 
 
 AST Parser::create_ast(const std::vector<Token> &tokens) const {
-    TokenStream token_iter{tokens};
-    AST root{token_iter};
-    return root;
+	TokenStream token_iter{tokens};
+	AST root{token_iter};
+	return root;
 }
 
 } // namespace nyan

--- a/nyan/patch_info.cpp
+++ b/nyan/patch_info.cpp
@@ -10,8 +10,7 @@
 
 namespace nyan {
 
-PatchInfo::PatchInfo(fqon_t &&target)
-	:
+PatchInfo::PatchInfo(fqon_t &&target) :
 	target{std::move(target)} {}
 
 

--- a/nyan/state.cpp
+++ b/nyan/state.cpp
@@ -7,19 +7,17 @@
 #include "compiler.h"
 #include "error.h"
 #include "object_state.h"
-#include "view.h"
 #include "util.h"
+#include "view.h"
 
 
 namespace nyan {
 
-State::State(const std::shared_ptr<State> &previous_state)
-	:
+State::State(const std::shared_ptr<State> &previous_state) :
 	previous_state{previous_state} {}
 
 
-State::State()
-	:
+State::State() :
 	previous_state{nullptr} {}
 
 
@@ -59,8 +57,7 @@ void State::update(std::shared_ptr<State> &&source_state) {
 		}
 		else {
 			this->objects.insert(
-				{std::move(it.first), std::move(it.second)}
-			);
+				{std::move(it.first), std::move(it.second)});
 		}
 	}
 }
@@ -69,7 +66,6 @@ void State::update(std::shared_ptr<State> &&source_state) {
 const std::shared_ptr<ObjectState> &State::copy_object(const fqon_t &name,
                                                        order_t t,
                                                        std::shared_ptr<View> &origin) {
-
 	// last known state of the object
 	const std::shared_ptr<ObjectState> &source = origin->get_raw(name, t);
 
@@ -81,10 +77,8 @@ const std::shared_ptr<ObjectState> &State::copy_object(const fqon_t &name,
 	auto it = this->objects.find(name);
 	if (it == std::end(this->objects)) {
 		// if not, copy the source object into this state
-		return this->objects.emplace(
-			name,
-			source->copy()
-		).first->second;
+		auto it_new_object = this->objects.emplace(name, source->copy()).first;
+		return it_new_object->second;
 	}
 	else {
 		// else, no need to copy, the object is already in this state
@@ -112,7 +106,7 @@ std::string State::str() const {
 	size_t i = 0;
 	for (auto &it : this->objects) {
 		builder << "object " << i << ":" << std::endl
-		        << it.first << " => " << it.second->str() << std::endl;
+				<< it.first << " => " << it.second->str() << std::endl;
 		i += 1;
 	}
 

--- a/nyan/state_history.cpp
+++ b/nyan/state_history.cpp
@@ -11,12 +11,10 @@
 namespace nyan {
 
 StateHistory::StateHistory(const std::shared_ptr<Database> &base) {
-
 	// create new empty state to work on at the beginning.
 	this->insert(
 		std::make_shared<State>(base->get_state()),
-		DEFAULT_T
-	);
+		DEFAULT_T);
 }
 
 const std::shared_ptr<State> &StateHistory::get_state(order_t t) const {
@@ -66,7 +64,6 @@ const std::shared_ptr<ObjectState> *StateHistory::get_obj_state(const fqon_t &fq
 
 
 void StateHistory::insert(std::shared_ptr<State> &&new_state, order_t t) {
-
 	// record the changes.
 	for (const auto &it : new_state->get_objects()) {
 		ObjectHistory &obj_history = this->get_create_obj_history(it.first);
@@ -86,9 +83,7 @@ void StateHistory::insert_linearization(std::vector<fqon_t> &&ins, order_t t) {
 
 
 const std::vector<fqon_t> &
-StateHistory::get_linearization(const fqon_t &obj, order_t t,
-                                const MetaInfo &meta_info) const {
-
+StateHistory::get_linearization(const fqon_t &obj, order_t t, const MetaInfo &meta_info) const {
 	const ObjectHistory *obj_hist = this->get_obj_history(obj);
 	if (obj_hist != nullptr) {
 		if (not obj_hist->linearizations.empty()) {
@@ -113,15 +108,12 @@ StateHistory::get_linearization(const fqon_t &obj, order_t t,
 void StateHistory::insert_children(const fqon_t &obj,
                                    std::unordered_set<fqon_t> &&ins,
                                    order_t t) {
-
 	this->get_create_obj_history(obj).children.insert_drop(t, std::move(ins));
 }
 
 
 const std::unordered_set<fqon_t> &
-StateHistory::get_children(const fqon_t &obj, order_t t,
-                           const MetaInfo &meta_info) const {
-
+StateHistory::get_children(const fqon_t &obj, order_t t, const MetaInfo &meta_info) const {
 	// first try the obj_history
 	const ObjectHistory *obj_hist = this->get_obj_history(obj);
 	if (obj_hist != nullptr) {
@@ -173,9 +165,8 @@ ObjectHistory &StateHistory::get_create_obj_history(const fqon_t &obj) {
 	}
 	else {
 		// create new obj_history entry.
-		return this->object_obj_hists.emplace(
-			obj, ObjectHistory{}
-		).first->second;
+		auto it_new_entry = this->object_obj_hists.emplace(obj, ObjectHistory{}).first;
+		return it_new_entry->second;
 	}
 }
 

--- a/nyan/state_history.h
+++ b/nyan/state_history.h
@@ -17,7 +17,6 @@ class ObjectState;
 class State;
 
 
-
 /**
  * Object state history tracking.
  */
@@ -89,8 +88,7 @@ public:
 	 *
 	 * @return C3 linearization of the object.
 	 */
-	const std::vector<fqon_t> &get_linearization(const fqon_t &obj, order_t t,
-	                                             const MetaInfo &meta_info) const;
+	const std::vector<fqon_t> &get_linearization(const fqon_t &obj, order_t t, const MetaInfo &meta_info) const;
 
 	/**
 	 * Record a change to the children of an object in its history.
@@ -110,11 +108,9 @@ public:
 	 *
 	 * @return List of children of the object.
 	 */
-	const std::unordered_set<fqon_t> &get_children(const fqon_t &obj, order_t t,
-	                                               const MetaInfo &meta_info) const;
+	const std::unordered_set<fqon_t> &get_children(const fqon_t &obj, order_t t, const MetaInfo &meta_info) const;
 
 protected:
-
 	/**
 	 * Get the object history an an object in the database.
 	 *

--- a/nyan/token.cpp
+++ b/nyan/token.cpp
@@ -12,24 +12,26 @@ namespace nyan {
 
 
 Token::Token(const std::shared_ptr<File> &file,
-             int line, int line_offset, int length,
-             token_type type)
-	:
+             int line,
+             int line_offset,
+             int length,
+             token_type type) :
 	location{file, line, line_offset, length},
 	type{type} {}
 
 
 Token::Token(const std::shared_ptr<File> &file,
-             int line, int line_offset, int length,
-             token_type type, const std::string &value)
-	:
+             int line,
+             int line_offset,
+             int length,
+             token_type type,
+             const std::string &value) :
 	location{file, line, line_offset, length},
 	type{type},
 	value{value} {}
 
 
-Token::Token()
-	:
+Token::Token() :
 	type{token_type::INVALID} {}
 
 
@@ -41,8 +43,8 @@ const std::string &Token::get() const {
 std::string Token::str() const {
 	std::ostringstream builder;
 	builder << "(" << this->location.get_line() << ":"
-	        << this->location.get_line_offset() << ": "
-	        << token_type_str(this->type);
+			<< this->location.get_line_offset() << ": "
+			<< token_type_str(this->type);
 	if (this->value.size() > 0) {
 		builder << " '" << this->value << "'";
 	}

--- a/nyan/token.h
+++ b/nyan/token.h
@@ -68,35 +68,64 @@ constexpr const char *token_type_str(token_type type) {
 	using namespace std::string_literals;
 
 	switch (type) {
-	case token_type::AS:             return "as";
-	case token_type::AT:             return "@";
-	case token_type::BANG:           return "!";
-	case token_type::COLON:          return "colon";
-	case token_type::COMMA:          return "comma";
-	case token_type::DEDENT:         return "dedentation";
-	case token_type::DOT:            return "dot";
-	case token_type::ELLIPSIS:       return "ellipsis";
-	case token_type::ENDFILE:        return "end of file";
-	case token_type::ENDLINE:        return "end of line";
-	case token_type::FLOAT:          return "float";
-	case token_type::FROM:           return "from";
-	case token_type::ID:             return "identifier";
-	case token_type::IMPORT:         return "import";
-	case token_type::INDENT:         return "indentation";
-	case token_type::INF:            return "inf";
-	case token_type::INT:            return "int";
-	case token_type::INVALID:        return "invalid";
-	case token_type::LANGLE:         return "'<'";
-	case token_type::LBRACE:         return "'{'";
-	case token_type::LBRACKET:       return "'['";
-	case token_type::LPAREN:         return "'('";
-	case token_type::OPERATOR:       return "operator";
-	case token_type::PASS:           return "pass";
-	case token_type::RANGLE:         return "'>'";
-	case token_type::RBRACE:         return "'}'";
-	case token_type::RBRACKET:       return "']'";
-	case token_type::RPAREN:         return "')'";
-	case token_type::STRING:         return "string";
+	case token_type::AS:
+		return "as";
+	case token_type::AT:
+		return "@";
+	case token_type::BANG:
+		return "!";
+	case token_type::COLON:
+		return "colon";
+	case token_type::COMMA:
+		return "comma";
+	case token_type::DEDENT:
+		return "dedentation";
+	case token_type::DOT:
+		return "dot";
+	case token_type::ELLIPSIS:
+		return "ellipsis";
+	case token_type::ENDFILE:
+		return "end of file";
+	case token_type::ENDLINE:
+		return "end of line";
+	case token_type::FLOAT:
+		return "float";
+	case token_type::FROM:
+		return "from";
+	case token_type::ID:
+		return "identifier";
+	case token_type::IMPORT:
+		return "import";
+	case token_type::INDENT:
+		return "indentation";
+	case token_type::INF:
+		return "inf";
+	case token_type::INT:
+		return "int";
+	case token_type::INVALID:
+		return "invalid";
+	case token_type::LANGLE:
+		return "'<'";
+	case token_type::LBRACE:
+		return "'{'";
+	case token_type::LBRACKET:
+		return "'['";
+	case token_type::LPAREN:
+		return "'('";
+	case token_type::OPERATOR:
+		return "operator";
+	case token_type::PASS:
+		return "pass";
+	case token_type::RANGLE:
+		return "'>'";
+	case token_type::RBRACE:
+		return "'}'";
+	case token_type::RBRACKET:
+		return "']'";
+	case token_type::RPAREN:
+		return "')'";
+	case token_type::STRING:
+		return "string";
 	}
 
 	return "unhandled token_type";
@@ -112,7 +141,6 @@ constexpr const char *token_type_str(token_type type) {
  * @return true if the token type requires a payload, else false.
  */
 constexpr bool token_needs_payload(token_type type) {
-
 	switch (type) {
 	case token_type::FLOAT:
 	case token_type::ID:

--- a/nyan/token_stream.cpp
+++ b/nyan/token_stream.cpp
@@ -9,8 +9,7 @@
 
 namespace nyan {
 
-TokenStream::TokenStream(const TokenStream::container_t &container)
-	:
+TokenStream::TokenStream(const TokenStream::container_t &container) :
 	container{container},
 	iter{std::begin(container)} {}
 

--- a/nyan/transaction.h
+++ b/nyan/transaction.h
@@ -3,14 +3,14 @@
 
 #include <exception>
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
 #include <string>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
-#include "config.h"
 #include "change_tracker.h"
+#include "config.h"
 
 
 namespace nyan {
@@ -24,7 +24,6 @@ class View;
  * Information to update for a view.
  */
 struct view_update {
-
 	using linearizations_t = std::vector<std::vector<fqon_t>>;
 
 	using child_map_t = std::unordered_map<fqon_t, std::unordered_set<fqon_t>>;
@@ -67,7 +66,6 @@ struct view_state {
  */
 class Transaction {
 public:
-
 	Transaction(order_t at, std::shared_ptr<View> &&origin);
 
 	/**

--- a/nyan/type.cpp
+++ b/nyan/type.cpp
@@ -20,10 +20,8 @@ namespace nyan {
 Type::Type(const ASTMemberType &root_ast_type,
            const NamespaceFinder &scope,
            const Namespace &ns,
-           const MetaInfo &type_info)
-	:
+           const MetaInfo &type_info) :
 	element_type{std::nullopt} {
-
 	// ast -> type conversion works like this:
 	// we fold all modifiers into binary flags, and intialize this type
 	// with the first non-modifier basic type.
@@ -44,17 +42,17 @@ Type::Type(const ASTMemberType &root_ast_type,
 	BasicType basic_type = BasicType::from_type_token(ast_type->name);
 
 	// validation method for the nested type count
-	auto expect_nested_types = [] (const BasicType &basic_type,
-	                               const ASTMemberType &ast_type) -> size_t {
+	auto expect_nested_types = [](const BasicType &basic_type,
+	                              const ASTMemberType &ast_type) -> size_t {
 		size_t count = basic_type.expected_nested_types();
-		if (not (count == ast_type.nested_types.size())) {
+		if (not(count == ast_type.nested_types.size())) {
 			throw ASTError{
 				std::string("only ")
-				+ std::to_string(ast_type.nested_types.size())
-				+ " container element types specified, expected "
-				+ std::to_string(count),
-				ast_type.name, false
-			};
+					+ std::to_string(ast_type.nested_types.size())
+					+ " container element types specified, expected "
+					+ std::to_string(count),
+				ast_type.name,
+				false};
 		}
 		return count;
 	};
@@ -102,7 +100,6 @@ Type::Type(const ASTMemberType &root_ast_type,
 		return;
 	}
 	else if (basic_type.is_composite()) {
-
 		size_t expected_element_types = expect_nested_types(basic_type, *ast_type);
 
 		std::vector<Type> nested_types{};
@@ -114,8 +111,7 @@ Type::Type(const ASTMemberType &root_ast_type,
 				ast_type->nested_types.at(i),
 				scope,
 				ns,
-				type_info
-			);
+				type_info);
 		}
 
 		switch (basic_type.composite_type) {
@@ -126,8 +122,7 @@ Type::Type(const ASTMemberType &root_ast_type,
 			if (nested_types[0].has_modifier(modifier_t::OPTIONAL)) {
 				throw TypeError{
 					ast_type->nested_types[0].name.get_start_location(),
-					"container key type can't be optional"
-				};
+					"container key type can't be optional"};
 			}
 			break;
 		default:
@@ -163,8 +158,7 @@ bool Type::is_container() const {
 
 
 bool Type::is_container(composite_t type) const {
-	return (this->basic_type.is_container() and
-	        this->get_composite_type() == type);
+	return (this->basic_type.is_container() and this->get_composite_type() == type);
 }
 
 
@@ -230,21 +224,18 @@ std::string Type::str() const {
 
 		if (unlikely(this->get_composite_type() == composite_t::SINGLE)) {
 			throw InternalError{
-				"single value encountered when expecting composite"
-			};
+				"single value encountered when expecting composite"};
 		}
 
 		std::ostringstream builder;
 
 		builder << composite_type_to_string(this->get_composite_type())
-		        << "(";
+				<< "(";
 
 		util::strjoin(
-			builder, ", ", this->get_element_type(),
-			[](auto &builder, auto& item) {
+			builder, ", ", this->get_element_type(), [](auto &builder, auto &item) {
 				builder << item.str();
-			}
-		);
+			});
 
 		builder << ")";
 
@@ -252,7 +243,7 @@ std::string Type::str() const {
 	}
 }
 
-bool Type::operator ==(const Type &other) const {
+bool Type::operator==(const Type &other) const {
 	if (not this->is_basic_type_match(other.get_basic_type())) {
 		return false;
 	}

--- a/nyan/type.h
+++ b/nyan/type.h
@@ -46,7 +46,6 @@ enum class modifier_t {
  */
 class Type {
 public:
-
 	//////////////////////////////////////////////////////////////////
 
 	/**
@@ -171,7 +170,7 @@ public:
 	 *
 	 * @return true if the types are equal, else false.
 	 */
-	bool operator ==(const Type &other) const;
+	bool operator==(const Type &other) const;
 
 protected:
 	/**

--- a/nyan/util.cpp
+++ b/nyan/util.cpp
@@ -4,8 +4,8 @@
 
 #include <cstring>
 #ifndef _MSC_VER
-#include <cxxabi.h>
-#include <dlfcn.h>
+	#include <cxxabi.h>
+	#include <dlfcn.h>
 #endif
 #include <cerrno>
 #include <fstream>
@@ -14,12 +14,12 @@
 #include <string>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-#include <array>
-#include <mutex>
+	#include <array>
+	#include <mutex>
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <DbgHelp.h>
+	#define WIN32_LEAN_AND_MEAN
+	#include <DbgHelp.h>
+	#include <Windows.h>
 
 
 namespace {
@@ -53,14 +53,13 @@ std::string symbol_name_win(const void *addr, bool require_exact_addr) {
 	constexpr int buffer_size = sizeof(SYMBOL_INFO) + name_buffer_size * sizeof(char);
 	std::array<char, buffer_size> buffer;
 
-	SYMBOL_INFO *symbol_info = reinterpret_cast<SYMBOL_INFO*>(buffer.data());
+	SYMBOL_INFO *symbol_info = reinterpret_cast<SYMBOL_INFO *>(buffer.data());
 
 	symbol_info->SizeOfStruct = sizeof(SYMBOL_INFO);
 	symbol_info->MaxNameLen = name_buffer_size;
 
 	DWORD64 symbol_offset = 0;
-	if (not SymFromAddr(process_handle, reinterpret_cast<DWORD64>(addr),
-	                    &symbol_offset, symbol_info)
+	if (not SymFromAddr(process_handle, reinterpret_cast<DWORD64>(addr), &symbol_offset, symbol_info)
 	    or (require_exact_addr and symbol_offset != 0)) {
 		return {};
 	}
@@ -69,7 +68,7 @@ std::string symbol_name_win(const void *addr, bool require_exact_addr) {
 }
 
 
-} // <anonymous> namespace
+} // namespace
 #endif
 
 
@@ -98,8 +97,8 @@ std::string read_file(const std::string &filename, bool binary) {
 	else {
 		std::ostringstream builder;
 		builder << "failed reading file '"
-		        << filename << "': "
-		        << strerror(errno);
+				<< filename << "': "
+				<< strerror(errno);
 		throw FileReadError{builder.str()};
 	}
 }
@@ -116,7 +115,8 @@ std::string demangle(const char *symbol) {
 
 	if (status != 0) {
 		return symbol;
-	} else {
+	}
+	else {
 		std::string result{buf};
 		free(buf);
 		return result;
@@ -133,7 +133,8 @@ std::string addr_to_string(const void *addr) {
 
 
 std::string symbol_name(const void *addr,
-                        bool require_exact_addr, bool no_pure_addrs) {
+                        bool require_exact_addr,
+                        bool no_pure_addrs) {
 #if defined(_WIN32) || defined(__CYGWIN__)
 	auto symbol_name_result = symbol_name_win(addr, require_exact_addr);
 
@@ -148,24 +149,23 @@ std::string symbol_name(const void *addr,
 	if (dladdr(addr, &addr_info) == 0) {
 		// dladdr has... failed.
 		return no_pure_addrs ? "" : addr_to_string(addr);
-	} else {
-		size_t symbol_offset = reinterpret_cast<size_t>(addr) -
-		                       reinterpret_cast<size_t>(addr_info.dli_saddr);
+	}
+	else {
+		size_t symbol_offset = reinterpret_cast<size_t>(addr) - reinterpret_cast<size_t>(addr_info.dli_saddr);
 
-		if (addr_info.dli_sname == nullptr or
-		    (symbol_offset != 0 and require_exact_addr)) {
-
+		if (addr_info.dli_sname == nullptr or (symbol_offset != 0 and require_exact_addr)) {
 			return no_pure_addrs ? "" : addr_to_string(addr);
 		}
 
 		if (symbol_offset == 0) {
 			// this is our symbol name.
 			return demangle(addr_info.dli_sname);
-		} else {
+		}
+		else {
 			std::ostringstream out;
 			out << demangle(addr_info.dli_sname)
-			    << "+0x" << std::hex
-			    << symbol_offset << std::dec;
+				<< "+0x" << std::hex
+				<< symbol_offset << std::dec;
 			return out.str();
 		}
 	}

--- a/nyan/util.h
+++ b/nyan/util.h
@@ -6,8 +6,8 @@
 #include <concepts>
 #include <functional>
 #include <iostream>
-#include <string>
 #include <sstream>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -25,7 +25,7 @@ namespace nyan::util {
  *
  * @return String with the file content.
  */
-std::string read_file(const std::string &filename, bool binary=false);
+std::string read_file(const std::string &filename, bool binary = false);
 
 
 /**
@@ -38,7 +38,7 @@ std::string demangle(const char *symbol);
 /**
  * Return the demangled symbol name for a given code address.
  */
-std::string symbol_name(const void *addr, bool require_exact_addr=true, bool no_pure_addrs=false);
+std::string symbol_name(const void *addr, bool require_exact_addr = true, bool no_pure_addrs = false);
 
 
 /**
@@ -73,7 +73,7 @@ concept Streamable = requires(std::ostream &os, T value) {
 template <typename T>
 concept Container = requires(T thing) {
 	// check for value_type type-member and iterator access.
-	{*std::begin(thing)} -> std::convertible_to<typename T::value_type>;
+	{ *std::begin(thing) } -> std::convertible_to<typename T::value_type>;
 	std::begin(thing) == std::end(thing);
 };
 
@@ -114,9 +114,7 @@ strjoin(
 	const std::string &delim,
 	const T &container,
 	const std::function<void(std::ostringstream &, const typename T::value_type &)>
-	func=&stream_container_elem<typename T::value_type>
-) {
-
+		func = &stream_container_elem<typename T::value_type>) {
 	for (bool use_delim = false; auto &entry : container) {
 		if (use_delim) {
 			builder << delim;
@@ -145,17 +143,13 @@ std::string strjoin(
 	const std::string &delim,
 	const T &container,
 	const std::function<const std::string_view(const typename T::value_type &)>
-	func=&convert_str<typename T::value_type>
-) {
+		func = &convert_str<typename T::value_type>) {
 	std::ostringstream builder;
 	strjoin(
-		builder, delim, container,
-		[&func](std::ostringstream &stream,
-		        const typename T::value_type &elem) {
+		builder, delim, container, [&func](std::ostringstream &stream, const typename T::value_type &elem) {
 			auto &&elem_str = func(elem);
 			stream << elem_str;
-		}
-	);
+		});
 	return std::move(builder).str();
 }
 
@@ -170,7 +164,7 @@ std::string strjoin(
  * @param[in]  delimiter Delimiter char at which the string is split.
  * @param[out] result Splitted string with type \p ret_t.
  */
-template<typename ret_t>
+template <typename ret_t>
 void split(const std::string &txt, char delimiter, ret_t result) {
 	std::stringstream splitter;
 	splitter.str(txt);
@@ -258,7 +252,8 @@ template <typename T, typename V>
 bool contains(const T &container, const V &value) {
 	if (std::find(std::begin(container),
 	              std::end(container),
-	              value) == std::end(container)) {
+	              value)
+	    == std::end(container)) {
 		return false;
 	}
 	else {
@@ -304,7 +299,7 @@ inline bool isinstance(const T *ptr) {
  * Test if the given reference is an instance of some base.
  */
 template <typename Base, typename T>
-requires (!std::is_pointer_v<T>)
+	requires(!std::is_pointer_v<T>)
 inline bool isinstance(const T &ref) {
 	return dynamic_cast<const Base *>(&ref) != nullptr;
 }

--- a/nyan/util/flags.h
+++ b/nyan/util/flags.h
@@ -24,14 +24,12 @@ namespace nyan::util {
  *   lolflags[lol::red] == true;
  */
 template <typename T>
-requires
-std::is_enum_v<T> &&
-requires {
-	{ T::size };
-}
+	requires std::is_enum_v<T> && requires {
+		{ T::size };
+	}
 class Flags {
 public:
-	Flags &set(T e, bool value=true) noexcept {
+	Flags &set(T e, bool value = true) noexcept {
 		this->bits.set(underlying(e), value);
 		return *this;
 	}

--- a/nyan/value/boolean.cpp
+++ b/nyan/value/boolean.cpp
@@ -6,24 +6,21 @@
 
 #include "../compiler.h"
 #include "../lang_error.h"
-#include "../util.h"
 #include "../token.h"
+#include "../util.h"
 
 
 namespace nyan {
 
-Boolean::Boolean(const bool &value)
-	:
+Boolean::Boolean(const bool &value) :
 	value{value} {}
 
 
 Boolean::Boolean(const IDToken &token) {
-
 	if (unlikely(token.get_type() != token_type::ID)) {
 		throw LangError{
 			token,
-			"invalid value for boolean"
-		};
+			"invalid value for boolean"};
 	}
 
 	const std::string &token_value = token.get_first();
@@ -37,16 +34,14 @@ Boolean::Boolean(const IDToken &token) {
 	else {
 		throw LangError{
 			token,
-			"unknown boolean value (did you use 'True' and 'False'?)"
-		};
+			"unknown boolean value (did you use 'True' and 'False'?)"};
 	}
 }
 
 
 ValueHolder Boolean::copy() const {
 	return ValueHolder{
-		std::make_shared<Boolean>(dynamic_cast<const Boolean &>(*this))
-	};
+		std::make_shared<Boolean>(dynamic_cast<const Boolean &>(*this))};
 }
 
 
@@ -55,13 +50,16 @@ bool Boolean::apply_value(const Value &value, nyan_op operation) {
 
 	switch (operation) {
 	case nyan_op::ASSIGN:
-		this->value = change.value; break;
+		this->value = change.value;
+		break;
 
 	case nyan_op::UNION_ASSIGN:
-		this->value |= change.value; break;
+		this->value |= change.value;
+		break;
 
 	case nyan_op::INTERSECT_ASSIGN:
-		this->value &= change.value; break;
+		this->value &= change.value;
+		break;
 
 	default:
 		throw Error{"unknown operation requested"};

--- a/nyan/value/boolean.h
+++ b/nyan/value/boolean.h
@@ -2,8 +2,8 @@
 #pragma once
 
 
-#include "value.h"
 #include "../id_token.h"
+#include "value.h"
 
 
 namespace nyan {

--- a/nyan/value/container.h
+++ b/nyan/value/container.h
@@ -21,14 +21,14 @@ namespace nyan {
  * The begin() and end() functions of the container class
  * instanciate this by wrapping it in the ContainerIterator below.
  */
-template<typename elem_type>
+template <typename elem_type>
 class ContainerIterBase {
 public:
 	using iterator_category = std::forward_iterator_tag;
 	using value_type = elem_type;
 	using difference_type = elem_type;
-	using pointer = elem_type*;
-	using reference = elem_type&;
+	using pointer = elem_type *;
+	using reference = elem_type &;
 
 	using this_type = ContainerIterBase<elem_type>;
 
@@ -38,18 +38,18 @@ public:
 	/**
 	 * Advance the iterator to the next element.
 	 */
-	virtual this_type &operator ++() = 0;
+	virtual this_type &operator++() = 0;
 
 	/**
 	 * Get the element the iterator is currently pointing to.
 	 */
-	virtual elem_type &operator *() const = 0;
+	virtual elem_type &operator*() const = 0;
 
 	/**
 	 * Compare if both iterators are pointing
 	 * to the same container position.
 	 */
-	bool operator ==(const ContainerIterBase &other) const {
+	bool operator==(const ContainerIterBase &other) const {
 		return (typeid(*this) == typeid(other)) and this->equals(other);
 	}
 
@@ -68,14 +68,14 @@ protected:
  *
  * Just relays the calls to the wrapped actual container.
  */
-template<typename T>
+template <typename T>
 class ContainerIterator {
 public:
 	using iterator_category = std::forward_iterator_tag;
 	using value_type = T;
 	using difference_type = T;
-	using pointer = T*;
-	using reference = T&;
+	using pointer = T *;
+	using reference = T &;
 
 	using elem_type = T;
 	using real_iterator = ContainerIterBase<elem_type>;
@@ -86,19 +86,18 @@ public:
 		:
 		iter{std::move(real)} {}
 
-	ContainerIterator(const ContainerIterator &other)
-		:
+	ContainerIterator(const ContainerIterator &other) :
 		iter{std::make_unique(other)} {}
 
 	ContainerIterator(ContainerIterator &&other) noexcept
 		:
 		iter{std::move(other.iter)} {}
 
-	ContainerIterator &operator =(const ContainerIterator &other) {
+	ContainerIterator &operator=(const ContainerIterator &other) {
 		this->iter = std::make_unique(other);
 	}
 
-	ContainerIterator &operator =(ContainerIterator &&other) noexcept {
+	ContainerIterator &operator=(ContainerIterator &&other) noexcept {
 		this->iter = std::move(other);
 	}
 
@@ -107,7 +106,7 @@ public:
 	/**
 	 * Advance the inner iterator to the next element.
 	 */
-	ContainerIterator &operator ++() {
+	ContainerIterator &operator++() {
 		++(*this->iter);
 		return *this;
 	}
@@ -115,7 +114,7 @@ public:
 	/**
 	 * Get the element the inner iterator points to.
 	 */
-	elem_type &operator *() const {
+	elem_type &operator*() const {
 		return *(*this->iter);
 	}
 
@@ -123,7 +122,7 @@ public:
 	 * Check if this iterator points to the same container element
 	 * as the other iterator.
 	 */
-	bool operator ==(const ContainerIterator& other) const {
+	bool operator==(const ContainerIterator &other) const {
 		return (this->iter == other.iter) or (*this->iter == *other.iter);
 	}
 
@@ -131,8 +130,8 @@ public:
 	 * Check if the iterator does not point to the same container element
 	 * as the other iterator.
 	 */
-	bool operator !=(const ContainerIterator& other) const {
-		return not (*this == other);
+	bool operator!=(const ContainerIterator &other) const {
+		return not(*this == other);
 	}
 
 protected:
@@ -153,14 +152,13 @@ public:
 	using this_type = DefaultIterator<iter_type, elem_type>;
 	using base_type = ContainerIterBase<elem_type>;
 
-	explicit DefaultIterator(iter_type &&iter)
-		:
+	explicit DefaultIterator(iter_type &&iter) :
 		iterator{std::move(iter)} {}
 
 	/**
 	 * Advance the iterator to the next element in the set.
 	 */
-	base_type &operator ++() override {
+	base_type &operator++() override {
 		++this->iterator;
 		return *this;
 	}
@@ -168,7 +166,7 @@ public:
 	/**
 	 * Return the iterator value.
 	 */
-	elem_type &operator *() const override {
+	elem_type &operator*() const override {
 		return *this->iterator;
 	}
 
@@ -250,12 +248,16 @@ public:
 	/**
 	 * Guarantee a const_iterator beginning.
 	 */
-	const_iterator cbegin() const { return this->begin(); };
+	const_iterator cbegin() const {
+		return this->begin();
+	};
 
 	/**
 	 * Guarantee a const_iterator end.
 	 */
-	const_iterator cend() const { return this->end(); };
+	const_iterator cend() const {
+		return this->end();
+	};
 
 	/**
 	 * Get an iterator to the first value holder in that container.
@@ -282,12 +284,16 @@ public:
 	/**
 	 * Guarantee a const_iterator to the value iterator beginning.
 	 */
-	holder_const_iterator values_cbegin() const { return this->values_begin(); };
+	holder_const_iterator values_cbegin() const {
+		return this->values_begin();
+	};
 
 	/**
 	 * Guarantee a const_iterator to the value iterator end.
 	 */
-	holder_const_iterator values_cend() const { return this->values_end(); };
+	holder_const_iterator values_cend() const {
+		return this->values_end();
+	};
 };
 
 } // namespace nyan

--- a/nyan/value/container_types.h
+++ b/nyan/value/container_types.h
@@ -3,8 +3,8 @@
 
 #include <unordered_set>
 
-#include "value_holder.h"
 #include "../datastructure/orderedset.h"
+#include "value_holder.h"
 
 
 namespace nyan {

--- a/nyan/value/dict.cpp
+++ b/nyan/value/dict.cpp
@@ -2,17 +2,17 @@
 
 #include "dict.h"
 
-#include "orderedset.h"
-#include "set.h"
 #include "../error.h"
 #include "../util.h"
+#include "orderedset.h"
+#include "set.h"
 
 
 namespace nyan {
 
 Dict::Dict() = default;
 
-Dict::Dict(std::unordered_map<ValueHolder,ValueHolder> &&values) {
+Dict::Dict(std::unordered_map<ValueHolder, ValueHolder> &&values) {
 	for (auto &value : values) {
 		this->values.insert(std::move(value));
 	}
@@ -30,11 +30,9 @@ std::string Dict::str() const {
 	std::ostringstream builder;
 	builder << "{";
 	builder << util::strjoin(
-		", ", this->values,
-		[] (const auto &val) {
+		", ", this->values, [](const auto &val) {
 			return val.first->str() + ": " + val.second->str();
-		}
-	);
+		});
 	builder << "}";
 
 	return builder.str();
@@ -47,11 +45,9 @@ std::string Dict::repr() const {
 	std::ostringstream builder;
 	builder << "{";
 	builder << util::strjoin(
-		", ", this->values,
-		[] (const auto &val) {
+		", ", this->values, [](const auto &val) {
 			return val.first->repr() + ": " + val.second->repr();
-		}
-	);
+		});
 	builder << "}";
 
 	return builder.str();
@@ -98,7 +94,7 @@ bool Dict::apply_value(const Value &value, nyan_op operation) {
 			break;
 		}
 
-		case nyan_op::INTERSECT_ASSIGN:{
+		case nyan_op::INTERSECT_ASSIGN: {
 			// only keep items that are in both. Both key
 			// and value must match.
 
@@ -174,7 +170,7 @@ bool Dict::apply_value(const Value &value, nyan_op operation) {
 	};
 
 
-	if (typeid(Set&) == typeid(value)) {
+	if (typeid(Set &) == typeid(value)) {
 		const Set *change = dynamic_cast<const Set *>(&value);
 
 		if (unlikely(change == nullptr)) {
@@ -187,9 +183,8 @@ bool Dict::apply_value(const Value &value, nyan_op operation) {
 		}
 
 		set_applier(this->values, change->get(), operation);
-
 	}
-	else if (typeid(OrderedSet&) == typeid(value)) {
+	else if (typeid(OrderedSet &) == typeid(value)) {
 		const OrderedSet *change = dynamic_cast<const OrderedSet *>(&value);
 
 		if (unlikely(change == nullptr)) {
@@ -202,9 +197,8 @@ bool Dict::apply_value(const Value &value, nyan_op operation) {
 		}
 
 		set_applier(this->values, change->get(), operation);
-
 	}
-	else if (typeid(Dict&) == typeid(value)) {
+	else if (typeid(Dict &) == typeid(value)) {
 		const Dict *change = dynamic_cast<const Dict *>(&value);
 
 		if (unlikely(change == nullptr)) {
@@ -227,7 +221,6 @@ bool Dict::apply_value(const Value &value, nyan_op operation) {
 }
 
 const std::unordered_set<nyan_op> &Dict::allowed_operations(const Type &with_type) const {
-
 	const static std::unordered_set<nyan_op> set_ops{
 		nyan_op::SUBTRACT_ASSIGN,
 		nyan_op::INTERSECT_ASSIGN,

--- a/nyan/value/dict.h
+++ b/nyan/value/dict.h
@@ -8,8 +8,8 @@
 #include "../compiler.h"
 #include "../util.h"
 #include "container.h"
-#include "value.h"
 #include "container_types.h"
+#include "value.h"
 
 
 namespace nyan {
@@ -26,14 +26,14 @@ public:
 	using element_type = typename value_storage::value_type;
 	using value_const_iterator = typename value_storage::const_iterator;
 
-	using iterator = ContainerIterator<std::pair<Value,Value>>;
-	using const_iterator = ContainerIterator<const std::pair<Value,Value>>;
+	using iterator = ContainerIterator<std::pair<Value, Value>>;
+	using const_iterator = ContainerIterator<const std::pair<Value, Value>>;
 
 	using holder_iterator = ContainerIterator<element_type>;
 	using holder_const_iterator = ContainerIterator<const element_type>;
 
 	Dict();
-	Dict(std::unordered_map<ValueHolder,ValueHolder> &&values);
+	Dict(std::unordered_map<ValueHolder, ValueHolder> &&values);
 
 
 	size_t hash() const override {
@@ -59,8 +59,7 @@ public:
 		throw Error{
 			"Dicts are only const-iterable. "
 			"make it const by using e.g. "
-			"for (auto &it = std::as_const(dict))"
-		};
+			"for (auto &it = std::as_const(dict))"};
 	}
 
 	iterator end() {
@@ -71,8 +70,7 @@ public:
 
 	holder_iterator values_begin() {
 		throw Error{
-			"Dict values holders are not non-const-iterable."
-		};
+			"Dict values holders are not non-const-iterable."};
 	}
 
 
@@ -90,9 +88,8 @@ public:
 	holder_const_iterator values_begin() const {
 		auto real_iterator = std::make_unique<
 			DefaultIterator<value_const_iterator,
-			                holder_const_iterator::elem_type>>(
-				                std::begin(this->values)
-			                );
+		                    holder_const_iterator::elem_type>>(
+			std::begin(this->values));
 
 		return holder_const_iterator{std::move(real_iterator)};
 	}
@@ -103,9 +100,8 @@ public:
 	holder_const_iterator values_end() const {
 		auto real_iterator = std::make_unique<
 			DefaultIterator<value_const_iterator,
-			                holder_const_iterator::elem_type>>(
-				                std::end(this->values)
-			                );
+		                    holder_const_iterator::elem_type>>(
+			std::end(this->values));
 
 		return holder_const_iterator{std::move(real_iterator)};
 	}

--- a/nyan/value/none.cpp
+++ b/nyan/value/none.cpp
@@ -19,7 +19,7 @@ ValueHolder None::copy() const {
 }
 
 
-bool None::apply_value(const Value &/**value*/, nyan_op /**operation*/) {
+bool None::apply_value(const Value & /**value*/, nyan_op /**operation*/) {
 	throw InternalError{"None can't get an applied value - assign Value directly to member instead"};
 }
 
@@ -39,7 +39,7 @@ size_t None::hash() const {
 }
 
 
-bool None::equals(const Value &/*other*/) const {
+bool None::equals(const Value & /*other*/) const {
 	// none always equals none,
 	// and `other` is ensured to be none by the `Value::operator==` check,
 	// which then calls this `equals` member method.

--- a/nyan/value/number.cpp
+++ b/nyan/value/number.cpp
@@ -6,8 +6,8 @@
 #include <typeinfo>
 
 #include "../compiler.h"
-#include "../lang_error.h"
 #include "../id_token.h"
+#include "../lang_error.h"
 #include "../ops.h"
 #include "../token.h"
 #include "../util.h"
@@ -16,30 +16,27 @@
 namespace nyan {
 
 static void check_token(const IDToken &token, std::vector<token_type> expected) {
-
 	using namespace std::string_literals;
 
-	if (unlikely(not (std::find(expected.begin(),
-	                            expected.end(),
-	                            token.get_type()) != expected.end()))) {
+	if (unlikely(not(std::find(expected.begin(),
+	                           expected.end(),
+	                           token.get_type())
+	                 != expected.end()))) {
 		throw LangError{
 			token,
 			"invalid value for number, expected "s
-			+ util::strjoin(
-				" or ",
-				expected,
-				[] (const auto &token_type) {
-					return token_type_str(token_type);
-				}
-			)
-		};
+				+ util::strjoin(
+					" or ",
+					expected,
+					[](const auto &token_type) {
+						return token_type_str(token_type);
+					})};
 	}
 }
 
 
-template<>
+template <>
 Int::Number(const IDToken &token) {
-
 	const static std::vector<token_type> expected{
 		token_type::INT,
 		token_type::INF,
@@ -69,9 +66,8 @@ Int::Number(const IDToken &token) {
 }
 
 
-template<>
+template <>
 Float::Number(const IDToken &token) {
-
 	const static std::vector<token_type> expected{
 		token_type::FLOAT,
 		token_type::INF,
@@ -103,8 +99,7 @@ Float::Number(const IDToken &token) {
 
 template <typename T>
 bool Number<T>::is_infinite() const {
-	return (this->value == this->infinite_pos() or
-	        this->value == this->infinite_neg());
+	return (this->value == this->infinite_pos() or this->value == this->infinite_neg());
 }
 
 template <typename T>
@@ -129,19 +124,24 @@ bool Number<T>::apply_value(const Value &value, nyan_op operation) {
 	auto applier = [this](auto operand, nyan_op operation) {
 		switch (operation) {
 		case nyan_op::ASSIGN:
-			this->value = operand; break;
+			this->value = operand;
+			break;
 
 		case nyan_op::ADD_ASSIGN:
-			this->value += operand; break;
+			this->value += operand;
+			break;
 
 		case nyan_op::SUBTRACT_ASSIGN:
-			this->value -= operand; break;
+			this->value -= operand;
+			break;
 
 		case nyan_op::MULTIPLY_ASSIGN:
-			this->value *= operand; break;
+			this->value *= operand;
+			break;
 
 		case nyan_op::DIVIDE_ASSIGN:
-			this->value /= operand; break;
+			this->value /= operand;
+			break;
 
 		default:
 			throw InternalError{"unknown operation requested"};
@@ -178,7 +178,7 @@ bool Number<T>::apply_value(const Value &value, nyan_op operation) {
 	}
 
 	// regular numbers without infinity
-	if (not (this->is_infinite() or number->is_infinite())) {
+	if (not(this->is_infinite() or number->is_infinite())) {
 		apply_number_convert(*number, operation);
 	}
 	else {
@@ -227,8 +227,7 @@ bool Number<T>::apply_value(const Value &value, nyan_op operation) {
 template <typename T>
 std::optional<typename Number<T>::infinity_action>
 Number<T>::handle_infinity(const NumberBase &other, nyan_op operation) {
-
-	auto inf_by_other = [&other](bool invert=false) {
+	auto inf_by_other = [&other](bool invert = false) {
 		if (other.is_infinite_positive() ^ invert) {
 			return infinity_action::INF_POS;
 		}
@@ -337,7 +336,6 @@ Number<T>::handle_infinity(const NumberBase &other, nyan_op operation) {
 template <typename T>
 const std::unordered_set<nyan_op> &
 Number<T>::allowed_operations(const Type &with_type) const {
-
 	const static std::unordered_set<nyan_op> ops{
 		nyan_op::ASSIGN,
 		nyan_op::ADD_ASSIGN,
@@ -358,22 +356,20 @@ Number<T>::allowed_operations(const Type &with_type) const {
 }
 
 
-template<>
+template <>
 const BasicType &Int::get_type() const {
 	constexpr static BasicType type{
 		primitive_t::INT,
-		composite_t::SINGLE
-	};
+		composite_t::SINGLE};
 	return type;
 }
 
 
-template<>
+template <>
 const BasicType &Float::get_type() const {
 	constexpr static BasicType type{
 		primitive_t::FLOAT,
-		composite_t::SINGLE
-	};
+		composite_t::SINGLE};
 
 	return type;
 }
@@ -395,10 +391,7 @@ template <>
 value_int_t Float::as_int() const {
 	// float -> int might overflow...
 	if (unlikely(
-		    (static_cast<value_float_t>(std::numeric_limits<value_int_t>::max()) < this->value) or
-		    (static_cast<value_float_t>(std::numeric_limits<value_int_t>::min()) > this->value)
-	    )) {
-
+			(static_cast<value_float_t>(std::numeric_limits<value_int_t>::max()) < this->value) or (static_cast<value_float_t>(std::numeric_limits<value_int_t>::min()) > this->value))) {
 		// we should handle this better instead of hard-crashing...
 		throw Error{"float to int conversion impossible since value wouldn't fit"};
 	}

--- a/nyan/value/number.h
+++ b/nyan/value/number.h
@@ -62,16 +62,15 @@ public:
 	 * this and other mean the current operand values.
 	 */
 	enum class infinity_action {
-		THIS,     //!< keep the value of this number
-		OTHER,    //!< take the value of the other number
-		INF_POS,  //!< set this to positive infinite
-		INF_NEG,  //!< set this to negative infinite
-		ZERO,     //!< set this to zero
+		THIS, //!< keep the value of this number
+		OTHER, //!< take the value of the other number
+		INF_POS, //!< set this to positive infinite
+		INF_NEG, //!< set this to negative infinite
+		ZERO, //!< set this to zero
 	};
 
 	Number(const IDToken &token);
-	Number(T value)
-		:
+	Number(T value) :
 		value{value} {}
 
 	ValueHolder copy() const override {
@@ -171,27 +170,26 @@ using Int = Number<value_int_t>;
 using Float = Number<value_float_t>;
 
 
-
-template<>
+template <>
 constexpr Float::storage_type
 Number<Float::storage_type>::infinite_pos() {
 	return std::numeric_limits<Float::storage_type>::infinity();
 }
 
-template<>
+template <>
 constexpr Float::storage_type
 Number<Float::storage_type>::infinite_neg() {
 	return -std::numeric_limits<Float::storage_type>::infinity();
 }
 
 
-template<>
+template <>
 constexpr Int::storage_type
 Number<Int::storage_type>::infinite_pos() {
 	return std::numeric_limits<Int::storage_type>::max();
 }
 
-template<>
+template <>
 constexpr Int::storage_type
 Number<Int::storage_type>::infinite_neg() {
 	return std::numeric_limits<Int::storage_type>::min();

--- a/nyan/value/object.cpp
+++ b/nyan/value/object.cpp
@@ -10,8 +10,7 @@
 
 namespace nyan {
 
-ObjectValue::ObjectValue(const fqon_t &name)
-	:
+ObjectValue::ObjectValue(const fqon_t &name) :
 	name{name} {}
 
 
@@ -25,7 +24,8 @@ bool ObjectValue::apply_value(const Value &value, nyan_op operation) {
 
 	switch (operation) {
 	case nyan_op::ASSIGN:
-		this->name = change.name; break;
+		this->name = change.name;
+		break;
 
 	default:
 		throw InternalError{"unknown operation requested"};

--- a/nyan/value/orderedset.cpp
+++ b/nyan/value/orderedset.cpp
@@ -42,11 +42,9 @@ std::string OrderedSet::str() const {
 	std::ostringstream builder;
 	builder << "o{";
 	builder << util::strjoin(
-		", ", this->values,
-		[] (const auto &val) {
+		", ", this->values, [](const auto &val) {
 			return val->str();
-		}
-	);
+		});
 	builder << "}";
 
 	return builder.str();
@@ -57,18 +55,15 @@ std::string OrderedSet::repr() const {
 	std::ostringstream builder;
 	builder << "o{";
 	builder << util::strjoin(
-		", ", this->values,
-		[] (const auto &val) {
+		", ", this->values, [](const auto &val) {
 			return val->repr();
-		}
-	);
+		});
 	builder << "}";
 	return builder.str();
 }
 
 
 const std::unordered_set<nyan_op> &OrderedSet::allowed_operations(const Type &with_type) const {
-
 	const static std::unordered_set<nyan_op> orderedset_ops{
 		nyan_op::ASSIGN,
 		nyan_op::ADD_ASSIGN,

--- a/nyan/value/orderedset.h
+++ b/nyan/value/orderedset.h
@@ -2,8 +2,8 @@
 #pragma once
 
 
-#include "set_base.h"
 #include "container_types.h"
+#include "set_base.h"
 
 #include "../ops.h"
 #include "value_holder.h"
@@ -19,7 +19,6 @@ class Value;
  */
 class OrderedSet
 	: public SetBase<ordered_set_t> {
-
 	// fetch the constructors
 	using SetBase<ordered_set_t>::SetBase;
 

--- a/nyan/value/set.cpp
+++ b/nyan/value/set.cpp
@@ -44,11 +44,9 @@ std::string Set::str() const {
 	std::ostringstream builder;
 	builder << "{";
 	builder << util::strjoin(
-		", ", this->values,
-		[] (const auto &val) {
+		", ", this->values, [](const auto &val) {
 			return val->str();
-		}
-	);
+		});
 	builder << "}";
 
 	return builder.str();
@@ -61,18 +59,15 @@ std::string Set::repr() const {
 	std::ostringstream builder;
 	builder << "{";
 	builder << util::strjoin(
-		", ", this->values,
-		[] (const auto &val) {
+		", ", this->values, [](const auto &val) {
 			return val->repr();
-		}
-	);
+		});
 	builder << "}";
 	return builder.str();
 }
 
 
 const std::unordered_set<nyan_op> &Set::allowed_operations(const Type &with_type) const {
-
 	const static std::unordered_set<nyan_op> set_ops{
 		nyan_op::ASSIGN,
 		nyan_op::ADD_ASSIGN,

--- a/nyan/value/set.h
+++ b/nyan/value/set.h
@@ -17,7 +17,6 @@ namespace nyan {
  */
 class Set
 	: public SetBase<set_t> {
-
 	// fetch the constructors
 	using SetBase<set_t>::SetBase;
 

--- a/nyan/value/set_base.h
+++ b/nyan/value/set_base.h
@@ -22,20 +22,19 @@ class Set;
  * i.e. it unpacks the ValueHolders!
  *
  */
-template<typename iter_type, typename elem_type>
+template <typename iter_type, typename elem_type>
 class SetIterator : public ContainerIterBase<elem_type> {
 public:
 	using this_type = SetIterator<iter_type, elem_type>;
 	using base_type = ContainerIterBase<elem_type>;
 
-	explicit SetIterator(iter_type &&iter)
-		:
+	explicit SetIterator(iter_type &&iter) :
 		iterator{std::move(iter)} {}
 
 	/**
 	 * Advance the iterator to the next element in the set.
 	 */
-	base_type &operator ++() override {
+	base_type &operator++() override {
 		++this->iterator;
 		return *this;
 	}
@@ -43,7 +42,7 @@ public:
 	/**
 	 * Get the element the iterator is currently pointing to.
 	 */
-	elem_type &operator *() const override {
+	elem_type &operator*() const override {
 		// unpack the ValueHolder!
 		return *(*this->iterator);
 	}
@@ -72,10 +71,10 @@ protected:
 template <typename T>
 class SetBase : public Container {
 public:
-	using Container::iterator;
 	using Container::const_iterator;
-	using Container::holder_iterator;
 	using Container::holder_const_iterator;
+	using Container::holder_iterator;
+	using Container::iterator;
 
 	using value_storage = T;
 	using element_type = typename value_storage::value_type;
@@ -110,8 +109,7 @@ public:
 		throw APIError{
 			"Sets are only const-iterable. "
 			"make it const by using e.g. "
-			"for (auto &it = std::as_const(container))"
-		};
+			"for (auto &it = std::as_const(container))"};
 	}
 
 	iterator end() override {
@@ -139,7 +137,7 @@ public:
 		// (this, true)        = use this set as target, use the beginning.
 		auto real_iterator = std::make_unique<
 			SetIterator<value_const_iterator,
-			            const_iterator::elem_type>>(std::begin(this->values));
+		                const_iterator::elem_type>>(std::begin(this->values));
 
 		return const_iterator{std::move(real_iterator)};
 	}
@@ -149,7 +147,7 @@ public:
 		// see explanation in the begin() above
 		auto real_iterator = std::make_unique<
 			SetIterator<value_const_iterator,
-			            const_iterator::elem_type>>(std::end(this->values));
+		                const_iterator::elem_type>>(std::end(this->values));
 
 		return const_iterator{std::move(real_iterator)};
 	}
@@ -157,8 +155,7 @@ public:
 
 	holder_iterator values_begin() override {
 		throw APIError{
-			"Set values holders are not non-const-iterable."
-		};
+			"Set values holders are not non-const-iterable."};
 	}
 
 
@@ -176,9 +173,8 @@ public:
 	holder_const_iterator values_begin() const override {
 		auto real_iterator = std::make_unique<
 			DefaultIterator<value_const_iterator,
-			                holder_const_iterator::elem_type>>(
-				                std::begin(this->values)
-			                );
+		                    holder_const_iterator::elem_type>>(
+			std::begin(this->values));
 
 		return holder_const_iterator{std::move(real_iterator)};
 	}
@@ -189,9 +185,8 @@ public:
 	holder_const_iterator values_end() const override {
 		auto real_iterator = std::make_unique<
 			DefaultIterator<value_const_iterator,
-			                holder_const_iterator::elem_type>>(
-				                std::end(this->values)
-			                );
+		                    holder_const_iterator::elem_type>>(
+			std::end(this->values));
 
 		return holder_const_iterator{std::move(real_iterator)};
 	}

--- a/nyan/value/text.h
+++ b/nyan/value/text.h
@@ -31,7 +31,7 @@ public:
 	const std::unordered_set<nyan_op> &allowed_operations(const Type &with_type) const override;
 	const BasicType &get_type() const override;
 
-	operator const std::string&() const {
+	operator const std::string &() const {
 		return this->value;
 	}
 

--- a/nyan/value/value.h
+++ b/nyan/value/value.h
@@ -129,7 +129,7 @@ public:
 	 *
 	 * @return true if the values are equal, else false.
 	 */
-	bool operator ==(const Value &other) const;
+	bool operator==(const Value &other) const;
 
 	/**
 	 * Inequality comparison for Values.
@@ -138,7 +138,7 @@ public:
 	 *
 	 * @return true if the values are not equal, else false.
 	 */
-	bool operator !=(const Value &other) const;
+	bool operator!=(const Value &other) const;
 
 protected:
 	/**
@@ -171,9 +171,9 @@ namespace std {
 /**
  * Hash for Values.
  */
-template<>
+template <>
 struct hash<nyan::Value> {
-	size_t operator ()(const nyan::Value &val) const {
+	size_t operator()(const nyan::Value &val) const {
 		return val.hash();
 	}
 };

--- a/nyan/value/value_holder.cpp
+++ b/nyan/value/value_holder.cpp
@@ -10,17 +10,15 @@ namespace nyan {
 ValueHolder::ValueHolder() = default;
 
 
-ValueHolder::ValueHolder(std::shared_ptr<Value> &&value)
-	:
+ValueHolder::ValueHolder(std::shared_ptr<Value> &&value) :
 	value{std::move(value)} {}
 
 
-ValueHolder::ValueHolder(const std::shared_ptr<Value> &value)
-	:
+ValueHolder::ValueHolder(const std::shared_ptr<Value> &value) :
 	value{value} {}
 
 
-ValueHolder &ValueHolder::operator =(const std::shared_ptr<Value> &value) {
+ValueHolder &ValueHolder::operator=(const std::shared_ptr<Value> &value) {
 	this->value = value;
 	return *this;
 }
@@ -36,22 +34,22 @@ bool ValueHolder::exists() const {
 }
 
 
-Value &ValueHolder::operator *() const {
+Value &ValueHolder::operator*() const {
 	return *this->value;
 }
 
 
-Value *ValueHolder::operator ->() const {
+Value *ValueHolder::operator->() const {
 	return this->value.get();
 }
 
 
-bool ValueHolder::operator ==(const ValueHolder &other) const  {
+bool ValueHolder::operator==(const ValueHolder &other) const {
 	return (*this->value == *other.value);
 }
 
 
-bool ValueHolder::operator !=(const ValueHolder &other) const {
+bool ValueHolder::operator!=(const ValueHolder &other) const {
 	return (*this->value != *other.value);
 }
 
@@ -61,7 +59,7 @@ bool ValueHolder::operator !=(const ValueHolder &other) const {
 
 namespace std {
 
-size_t hash<nyan::ValueHolder>::operator ()(const nyan::ValueHolder &val) const {
+size_t hash<nyan::ValueHolder>::operator()(const nyan::ValueHolder &val) const {
 	return hash<nyan::Value>{}(*val);
 }
 

--- a/nyan/value/value_holder.h
+++ b/nyan/value/value_holder.h
@@ -23,7 +23,7 @@ public:
 	/**
 	 * Assign a new value to the holder.
 	 */
-	ValueHolder &operator =(const std::shared_ptr<Value> &value);
+	ValueHolder &operator=(const std::shared_ptr<Value> &value);
 
 	/**
 	 * Get the shared pointer of this ValueHolder.
@@ -44,28 +44,28 @@ public:
 	 *
 	 * @return Value stored at this holder's pointer.
 	 */
-	Value &operator *() const;
+	Value &operator*() const;
 
 	/**
 	 * Get the shared pointer of this ValueHolder.
 	 *
 	 * @return Shared pointer to this holder's value.
 	 */
-	Value *operator ->() const;
+	Value *operator->() const;
 
 	/**
 	 * Compare two ValueHolders for equality.
 	 *
 	 * @return true if the values stored by the holders are equal, else false.
 	 */
-	bool operator ==(const ValueHolder &other) const;
+	bool operator==(const ValueHolder &other) const;
 
 	/**
 	 * Compare two ValueHolders for inequality.
 	 *
 	 * @return true if the values stored by the holders are not equal, else false.
 	 */
-	bool operator !=(const ValueHolder &other) const;
+	bool operator!=(const ValueHolder &other) const;
 
 protected:
 	/**
@@ -85,8 +85,7 @@ namespace std {
  */
 template <>
 struct hash<nyan::ValueHolder> {
-	size_t operator ()(const nyan::ValueHolder &val) const;
+	size_t operator()(const nyan::ValueHolder &val) const;
 };
 
 } // namespace std
-

--- a/nyan/value_token.cpp
+++ b/nyan/value_token.cpp
@@ -11,24 +11,19 @@
 namespace nyan {
 
 
-ValueToken::ValueToken(const IDToken &token)
-	:
+ValueToken::ValueToken(const IDToken &token) :
 	container_type{composite_t::SINGLE} {
-
 	this->tokens.push_back(token);
 }
 
 
 ValueToken::ValueToken(composite_t type,
-                       std::vector<IDToken> &tokens)
-	:
+                       std::vector<IDToken> &tokens) :
 	tokens{tokens} {
-
 	const static std::unordered_set<composite_t> container_types{
 		composite_t::SET,
 		composite_t::ORDEREDSET,
-		composite_t::DICT
-	};
+		composite_t::DICT};
 
 	if (container_types.find(type) == container_types.end()) {
 		throw InternalError{"unknown container value type"};
@@ -81,8 +76,7 @@ size_t ValueToken::get_length() const {
 
 	case composite_t::DICT:
 		// key token length + value token length + separating ": " length
-		return this->tokens.at(0).get_length() +
-		this->tokens.at(1).get_length() + 2;
+		return this->tokens.at(0).get_length() + this->tokens.at(1).get_length() + 2;
 
 	default:
 		throw InternalError{"unknown container value type"};

--- a/nyan/view.cpp
+++ b/nyan/view.cpp
@@ -12,8 +12,7 @@
 namespace nyan {
 
 
-View::View(const std::shared_ptr<Database> &database)
-	:
+View::View(const std::shared_ptr<Database> &database) :
 	database{database},
 	state{database} {}
 
@@ -117,19 +116,16 @@ std::unordered_set<fqon_t> View::get_obj_children_all(const fqon_t &fqon, order_
 
 std::shared_ptr<ObjectNotifier> View::create_notifier(const fqon_t &fqon,
                                                       const update_cb_t &callback) {
-
 	auto it = this->notifiers.find(fqon);
 	decltype(this->notifiers)::mapped_type *notifier_set = nullptr;
 
 	if (it == std::end(this->notifiers)) {
-
 		// create new set, add to object map and and get pointer
 		auto ins = this->notifiers.insert(
 			{
 				fqon,
 				std::unordered_set<std::shared_ptr<ObjectNotifierHandle>>{},
-			}
-		);
+			});
 
 		notifier_set = &ins.first->second;
 	}
@@ -138,7 +134,7 @@ std::shared_ptr<ObjectNotifier> View::create_notifier(const fqon_t &fqon,
 	}
 
 	auto notifier = std::make_shared<ObjectNotifier>(fqon, callback, this->shared_from_this());
-	const auto& handle = notifier->get_handle();
+	const auto &handle = notifier->get_handle();
 	notifier_set->insert(handle);
 	return notifier;
 }
@@ -173,11 +169,9 @@ void View::fire_notifications(const std::unordered_set<fqon_t> &changed_objs,
 }
 
 
-
 void View::gather_obj_children(std::unordered_set<fqon_t> &target,
                                const fqon_t &obj,
                                order_t t) const {
-
 	for (auto &child : this->get_obj_children(obj, t)) {
 		target.insert(child);
 
@@ -188,7 +182,6 @@ void View::gather_obj_children(std::unordered_set<fqon_t> &target,
 		this->gather_obj_children(target, child, t);
 	}
 }
-
 
 
 StateHistory &View::get_state_history() {

--- a/nyan/view.h
+++ b/nyan/view.h
@@ -26,16 +26,17 @@ class State;
  */
 class View : public std::enable_shared_from_this<View> {
 	friend class Transaction;
+
 public:
 	View(const std::shared_ptr<Database> &database);
 
 	Object get_object(const fqon_t &fqon);
 
-	const std::shared_ptr<ObjectState> &get_raw(const fqon_t &fqon, order_t t=LATEST_T) const;
+	const std::shared_ptr<ObjectState> &get_raw(const fqon_t &fqon, order_t t = LATEST_T) const;
 
 	const ObjectInfo &get_info(const fqon_t &fqon) const;
 
-	Transaction new_transaction(order_t t=DEFAULT_T);
+	Transaction new_transaction(order_t t = DEFAULT_T);
 
 	std::shared_ptr<View> new_child();
 
@@ -44,18 +45,18 @@ public:
 
 	const Database &get_database() const;
 
-	const std::vector<fqon_t> &get_linearization(const fqon_t &fqon, order_t t=LATEST_T) const;
+	const std::vector<fqon_t> &get_linearization(const fqon_t &fqon, order_t t = LATEST_T) const;
 
 	/**
 	 * Get the direct ancestor children of an object.
 	 * Does not step further down than one inheritance level.
 	 */
-	const std::unordered_set<fqon_t> &get_obj_children(const fqon_t &fqon, order_t t=LATEST_T) const;
+	const std::unordered_set<fqon_t> &get_obj_children(const fqon_t &fqon, order_t t = LATEST_T) const;
 
 	/**
 	 * Get all ancestor children of an object including the transitive onces.
 	 */
-	std::unordered_set<fqon_t> get_obj_children_all(const fqon_t &fqon, order_t t=LATEST_T) const;
+	std::unordered_set<fqon_t> get_obj_children_all(const fqon_t &fqon, order_t t = LATEST_T) const;
 
 	/**
 	 * Register a function that is called whenever the given object or any of its parents


### PR DESCRIPTION
We use a `.clang-format` file for our code style but most code in the repo does not adhere to this style. This PR changes that.

Depends on #119