### PR TITLE
Allow retrieving `nyan::Object` handle as `shared_ptr`

### DIFF
--- a/nyan/view.cpp
+++ b/nyan/view.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "view.h"
 
@@ -23,6 +23,13 @@ Object View::get_object(const fqon_t &fqon) {
 
 	// TODO: store info in object to avoid further lookups.
 	return Object{fqon, shared_from_this()};
+}
+
+const std::shared_ptr<Object> View::get_object_ptr(const fqon_t &fqon) {
+	// test for object existence
+	this->get_info(fqon);
+
+	return std::make_shared<Object>(Object::Restricted{}, fqon, shared_from_this());
 }
 
 

--- a/nyan/view.h
+++ b/nyan/view.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 #pragma once
 
 #include <memory>
@@ -31,6 +31,7 @@ public:
 	View(const std::shared_ptr<Database> &database);
 
 	Object get_object(const fqon_t &fqon);
+	const std::shared_ptr<Object> get_object_ptr(const fqon_t &fqon);
 
 	const std::shared_ptr<ObjectState> &get_raw(const fqon_t &fqon, order_t t = LATEST_T) const;
 


### PR DESCRIPTION
This allows fetching a `nyan::Object` from a `nyan::View` as `std::shared_ptr`.

Even though https://github.com/SFTtech/nyan/blob/19e742a609a9b3c01407a93b37b18344726da8a7/nyan/object.h#L63-L67 is in the code, I'm not sure why nyan::Object handles shouldn't be shared. I might be missing something there, but I don't see the disadvantage of enabling the shared pointers.

The main motivation for this change is a change to the activity system in openage PR https://github.com/SFTtech/openage/pull/1688 to include `nyan::Object`s. Using raw objects/references makes testing the activity system more complicated as it requires us to initialize a whole nyan database for the tests. If we use shared pointers, we can get away with nullptr wrapped in shared_ptr as a workaround. 