### PR TITLE
Update clang-format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,8 @@ AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignEscapedNewlines: DontAlign
 AlignOperands:   Align
-AlignTrailingComments: false
+AlignTrailingComments:
+  Kind: Leave
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
@@ -55,6 +56,7 @@ BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: BeforeComma
 BreakStringLiterals: false
+# clang-format 19 BreakTemplateDeclarations: Yes
 ColumnLimit:     0
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -84,7 +86,7 @@ IndentGotoLabels: false
 IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
-# clang-format-16 InsertNewlineAtEOF: true
+InsertNewlineAtEOF: true
 InsertTrailingCommas: Wrapped
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
@@ -100,7 +102,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
-ReflowComments: false
+ReflowComments: Always
 SortIncludes:    CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/nyan/compiler.h
+++ b/nyan/compiler.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2016-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #pragma once
 
@@ -34,7 +34,7 @@
 		#define NYANAPI __declspec(dllexport) // library is built
 	#else
 		#define NYANAPI __declspec(dllimport) // library is used
-	#endif /* nyan_EXPORTS */
+	#endif
 #else
 	#define NYANAPI __attribute__((visibility("default")))
 #endif

--- a/nyan/database.cpp
+++ b/nyan/database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2024 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "database.h"
 
@@ -532,7 +532,7 @@ void Database::resolve_types(const std::vector<fqon_t> &new_objects) {
 						// check if the member we're looking for isn't already typed.
 						if (unlikely(member_info.is_initial_def())) {
 							// another parent defines this type,
-							// which is disallowed!
+						    // which is disallowed!
 
 							// TODO: show location of infringing type instead of member
 							throw LangError{
@@ -546,7 +546,7 @@ void Database::resolve_types(const std::vector<fqon_t> &new_objects) {
 						member_info.set_type(new_type, false);
 					}
 					// else that member knows the type,
-					// but we're looking for the initial definition.
+				    // but we're looking for the initial definition.
 
 					// we need to traverse all members and never stop early.
 					return false;

--- a/nyan/error.cpp
+++ b/nyan/error.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2016-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "error.h"
 
@@ -8,7 +8,7 @@
 	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
 	// TODO - CaptureStackBackTrace doesn't report number of frames available
-	// need to implement increase buffer size
+    // need to implement increase buffer size
 	#define backtrace(buffer, buf_size) CaptureStackBackTrace(0, buf_size, buffer, NULL)
 #else
 	#include <execinfo.h>

--- a/nyan/lexer/bracket.h
+++ b/nyan/lexer/bracket.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 #pragma once
 
 
@@ -41,22 +41,22 @@ protected:
 	token_type expected_match() const;
 
 	/**
-     * Indentation level of the line this bracket was in.
-     */
+	 * Indentation level of the line this bracket was in.
+	 */
 	int indentation;
 
 	/**
-     * Type of this opening bracket.
-     */
+	 * Type of this opening bracket.
+	 */
 	bracket_type type;
 
 	/**
-     * true if the indentation mode is "hanging",
-     * that is, if a continuation must happen at the
-     * indent level of this opening bracket.
-     * The expected indentation level of contained content is stored
-     * in the `indentation` member.
-     */
+	 * true if the indentation mode is "hanging",
+	 * that is, if a continuation must happen at the
+	 * indent level of this opening bracket.
+	 * The expected indentation level of contained content is stored
+	 * in the `indentation` member.
+	 */
 	bool hanging;
 };
 

--- a/nyan/lexer/impl.h
+++ b/nyan/lexer/impl.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 #pragma once
 
 #include <queue>
@@ -27,8 +27,8 @@ public:
 	Token generate_token();
 
 	/** @name FlexInterfaceMethods
- * Methods used by the flex generated lexer.
- */
+	 * Methods used by the flex generated lexer.
+	 */
 	///@{
 
 	/** Advance the line position by match length. */

--- a/nyan/namespace_finder.cpp
+++ b/nyan/namespace_finder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "namespace_finder.h"
 
@@ -32,9 +32,11 @@ void NamespaceFinder::add_alias(const Token &alias,
 
 
 bool NamespaceFinder::check_conflict(const std::string &name) const {
-	return (this->aliases.find(name) != std::end(this->aliases) // aliases
-	        // importing files from the root directory can be a problem too
-	        or this->imports.find(Namespace{std::vector<std::string>(), name}) != std::end(this->imports));
+	return (
+		// aliases must be unique
+		this->aliases.find(name) != std::end(this->aliases)
+		// importing files from the root directory can be a problem too
+		or this->imports.find(Namespace{std::vector<std::string>(), name}) != std::end(this->imports));
 }
 
 

--- a/nyan/token_stream.cpp
+++ b/nyan/token_stream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2016-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "token_stream.h"
 
@@ -26,7 +26,7 @@ const TokenStream::tok_t *TokenStream::next() {
 
 	ret = &(*this->iter);
 
-	//std::cout << "tok: " << ret->str() << std::endl;
+	// std::cout << "tok: " << ret->str() << std::endl;
 
 	this->iter = std::next(this->iter);
 	return ret;

--- a/nyan/transaction.cpp
+++ b/nyan/transaction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2017-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "transaction.h"
 
@@ -108,7 +108,7 @@ bool Transaction::add(const Object &patch) {
 			// apply all patch parents in order (last the patch itself)
 			target_obj->apply(
 				// TODO: use the same mechanism as above to get only parent
-				//       obj states of base_state
+			    //       obj states of base_state
 				view->get_raw(patch_name, this->at),
 				view->get_info(patch_name),
 				patch_tracker);

--- a/nyan/util.cpp
+++ b/nyan/util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 the nyan authors, LGPLv3+. See copying.md for legal info.
+// Copyright 2016-2025 the nyan authors, LGPLv3+. See copying.md for legal info.
 
 #include "util.h"
 
@@ -18,8 +18,12 @@
 	#include <mutex>
 
 	#define WIN32_LEAN_AND_MEAN
+// clang-format off
+// prevent clang-format from reordering these includes
+// DbgHelp.h must be included AFTER Windows.h
 	#include <Windows.h>
 	#include <DbgHelp.h>
+// clang-format on
 
 
 namespace {


### PR DESCRIPTION
Updates the clang format rules to a newer clang-format version. I also tried to sync the rules with the openage formatting (see [here](https://github.com/SFTtech/openage/blob/master/.clang-format)).